### PR TITLE
Authorization

### DIFF
--- a/examples/ghost/src/data-sources/AuthSource.ts
+++ b/examples/ghost/src/data-sources/AuthSource.ts
@@ -1,0 +1,17 @@
+import { Context } from "./Context";
+
+export class AuthSource {
+  constructor(protected ctx: Context) {}
+
+  async canViewPost(id: string): Promise<boolean> {
+    const post = await this.ctx.post.byId(id);
+    if (post.status === "published") {
+      return true;
+    }
+    return false;
+  }
+
+  async canViewUser(id: string): Promise<boolean> {
+    return true;
+  }
+}

--- a/examples/ghost/src/data-sources/Context.ts
+++ b/examples/ghost/src/data-sources/Context.ts
@@ -1,8 +1,10 @@
 import { PostSource } from "./PostSource";
 import { UserSource } from "./UserSource";
+import { AuthSource } from "./AuthSource";
 import { knex } from "../utils/knexInstance";
 
 export class Context {
+  auth = new AuthSource(this);
   post = new PostSource(this);
   user = new UserSource(this);
 

--- a/examples/ghost/src/data-sources/PostSource.ts
+++ b/examples/ghost/src/data-sources/PostSource.ts
@@ -1,10 +1,14 @@
 import DataLoader from "dataloader";
 import { Context } from "./Context";
 import { dbt } from "../generated";
-import { byColumnLoader } from "../utils/loaderUtils";
+import { byColumnLoader, manyByColumnLoader } from "../utils/loaderUtils";
 
 export class PostSource {
   constructor(protected ctx: Context) {}
+
+  authorIdsLoader = new DataLoader<string, dbt.PostsAuthors[]>((ids) => {
+    return manyByColumnLoader(this.ctx, "postsAuthors", "postId", ids);
+  });
 
   byIdLoader = new DataLoader<string, dbt.Posts>((ids) => {
     return byColumnLoader(this.ctx, "posts", "id", ids);
@@ -12,5 +16,15 @@ export class PostSource {
 
   byId(id: string) {
     return this.byIdLoader.load(id);
+  }
+
+  async authorIds(postId: string) {
+    const result = await this.authorIdsLoader.load(postId);
+    return result.map(({ authorId }) => authorId);
+  }
+
+  async authors(postId: string) {
+    const authorIds = await this.authorIds(postId);
+    return this.ctx.user.byIdLoader.loadMany(authorIds);
   }
 }

--- a/examples/ghost/src/schema/Query.ts
+++ b/examples/ghost/src/schema/Query.ts
@@ -14,6 +14,7 @@ export const Query = queryType({
     t.field("postById", {
       type: Post,
       args: { id: idArg() },
+      authorize: (root, args, ctx) => ctx.auth.canViewPost(args.id),
       resolve(root, args, ctx) {
         return ctx.post.byId(args.id);
       },
@@ -21,6 +22,7 @@ export const Query = queryType({
     t.field("userById", {
       type: User,
       args: { id: idArg() },
+      authorize: (root, args, ctx) => ctx.auth.canViewUser(args.id),
       resolve(root, args, ctx) {
         return ctx.user.byId(args.id);
       },

--- a/examples/ghost/src/utils/loaderUtils.ts
+++ b/examples/ghost/src/utils/loaderUtils.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { DBTables } from "../generated/ghost-db-tables";
 import { Context } from "../data-sources/Context";
+import { QueryBuilder } from "knex";
 
 export function byColumnLoader<
   Tbl extends keyof DBTables,
@@ -22,4 +23,33 @@ export function byColumnLoader<
         return keyed[k] || new Error(`Missing row for ${table}:${key} ${k}`);
       });
     });
+}
+
+/**
+ * A type-safe loader for loading many of a particular item,
+ * grouped by an individual key.
+ * @param ctx
+ * @param table
+ * @param key
+ * @param keys
+ */
+export function manyByColumnLoader<
+  Tbl extends keyof DBTables,
+  Key extends Extract<keyof DBTables[Tbl], string>,
+  KeyType extends Extract<DBTables[Tbl][Key], string | number>
+>(
+  ctx: Context,
+  tableName: Tbl,
+  key: Key,
+  keys: KeyType[],
+  scope: (qb: QueryBuilder) => QueryBuilder = (qb) => qb
+) {
+  const builder = ctx
+    .knex(tableName)
+    .select(`${tableName}.*`)
+    .whereIn(`${tableName}.${key}`, _.uniq(keys));
+  return scope(builder).then((rows: DBTables[Tbl][]) => {
+    const grouped = _.groupBy(rows, key);
+    return keys.map((id) => grouped[id] || []);
+  });
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -32,6 +32,7 @@ import {
   isOutputType,
   isUnionType,
   isScalarType,
+  defaultFieldResolver,
 } from "graphql";
 import { NexusArgConfig, NexusArgDef } from "./definitions/args";
 import {
@@ -81,11 +82,16 @@ import {
   GraphQLPossibleInputs,
   GraphQLPossibleOutputs,
   NonNullConfig,
+  WrappedResolver,
 } from "./definitions/_types";
 import { TypegenAutoConfigOptions } from "./typegenAutoConfig";
 import { TypegenFormatFn } from "./typegenFormatPrettier";
 import { TypegenMetadata } from "./typegenMetadata";
-import { AbstractTypeResolver, GetGen } from "./typegenTypeHelpers";
+import {
+  AbstractTypeResolver,
+  GetGen,
+  AuthorizeResolver,
+} from "./typegenTypeHelpers";
 import { firstDefined, objValues, suggestionList, isObject } from "./utils";
 
 export type Maybe<T> = T | null;
@@ -506,9 +512,9 @@ export class SchemaBuilder {
     return type;
   }
 
-  protected withScalarMethods<T extends NexusGenCustomDefinitionMethods<string>>(
-    definitionBlock: T
-  ): T {
+  protected withScalarMethods<
+    T extends NexusGenCustomDefinitionMethods<string>
+  >(definitionBlock: T): T {
     this.customScalarMethods.forEach(([methodName, typeName]) => {
       // @ts-ignore - Yeah, yeah... we know
       definitionBlock[methodName] = function(fieldName, ...opts) {
@@ -888,6 +894,12 @@ export class SchemaBuilder {
     if (!resolver && !forInterface) {
       resolver = (typeConfig as NexusObjectTypeConfig<any>).defaultResolver;
     }
+    if (fieldOptions.authorize) {
+      resolver = wrapAuthorize(
+        resolver || defaultFieldResolver,
+        fieldOptions.authorize
+      );
+    }
     return resolver;
   }
 
@@ -907,6 +919,33 @@ function extendError(name: string) {
   return new Error(
     `${name} was already defined and imported as a type, check the docs for extending types`
   );
+}
+
+export function wrapAuthorize(
+  resolver: GraphQLFieldResolver<any, any>,
+  authorize: AuthorizeResolver<string, any>
+): GraphQLFieldResolver<any, any> {
+  const nexusAuthWrapped: WrappedResolver = async (root, args, ctx, info) => {
+    const authResult = await authorize(root, args, ctx, info);
+    if (authResult === true) {
+      return resolver(root, args, ctx, info);
+    }
+    if (authResult === false) {
+      throw new Error("Not authorized");
+    }
+    if (authResult instanceof Error) {
+      throw authResult;
+    }
+    const {
+      fieldName,
+      parentType: { name: parentTypeName },
+    } = info;
+    throw new Error(
+      `Nexus authorize for ${parentTypeName}.${fieldName} Expected a boolean or Error, saw ${authResult}`
+    );
+  };
+  nexusAuthWrapped.nexusWrappedResolver = resolver;
+  return nexusAuthWrapped;
 }
 
 export interface BuildTypes<

--- a/src/definitions/_types.ts
+++ b/src/definitions/_types.ts
@@ -2,7 +2,12 @@ import {
   GraphQLLeafType,
   GraphQLCompositeType,
   GraphQLInputObjectType,
+  GraphQLFieldResolver,
 } from "graphql";
+
+export type WrappedResolver = GraphQLFieldResolver<any, any> & {
+  nexusWrappedResolver?: GraphQLFieldResolver<any, any>;
+};
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -4,6 +4,7 @@ import {
   GetGen,
   HasGen3,
   NeedsResolver,
+  AuthorizeResolver,
 } from "../typegenTypeHelpers";
 import { NexusArgDef } from "./args";
 import {
@@ -52,6 +53,15 @@ export interface OutputScalarConfig<
    * Resolve method for the field
    */
   resolve?: FieldResolver<TypeName, FieldName>;
+  /**
+   * Authorization for an individual field. Returning "true"
+   * or "Promise<true>" means the field can be accessed.
+   * Returning "false" or "Promise<false>" will respond
+   * with a "Not Authorized" error for the field. Returning
+   * or throwing an error will also prevent the resolver from
+   * executing.
+   */
+  authorize?: AuthorizeResolver<TypeName, FieldName>;
 }
 
 export interface NexusOutputFieldConfig<

--- a/src/definitions/objectType.ts
+++ b/src/definitions/objectType.ts
@@ -78,7 +78,6 @@ export interface NexusObjectTypeConfig<TypeName extends string> {
   description?: string | null;
   /**
    * Specifies a default field resolver for all members of this type.
-   * Warning: this may break type-safety.
    */
   defaultResolver?: FieldResolver<TypeName, any>;
 }

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -21,9 +21,11 @@ import {
   isUnionType,
   GraphQLInputObjectType,
   GraphQLEnumType,
+  defaultFieldResolver,
 } from "graphql";
 import { TypegenInfo } from "./builder";
 import { eachObj, GroupedTypes, groupTypes, mapObj } from "./utils";
+import { WrappedResolver } from "./definitions/_types";
 
 const SpecifiedScalars = {
   ID: "string",
@@ -344,10 +346,15 @@ export class Typegen {
   }
 
   hasResolver(
-    field: GraphQLField<any, any>,
+    field: GraphQLField<any, any> & { resolve?: WrappedResolver },
     _type: GraphQLObjectType | GraphQLInterfaceType // Used in tests
   ) {
-    return Boolean(field.resolve);
+    if (field.resolve) {
+      if (field.resolve.nexusWrappedResolver !== defaultFieldResolver) {
+        return true;
+      }
+    }
+    return false;
   }
 
   printRootTypeMap() {

--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -79,6 +79,16 @@ export type FieldResolver<TypeName extends string, FieldName extends string> = (
   info: GraphQLResolveInfo
 ) => MaybePromiseDeep<ResultValue<TypeName, FieldName>>;
 
+export type AuthorizeResolver<
+  TypeName extends string,
+  FieldName extends string
+> = (
+  root: RootValue<TypeName>,
+  args: ArgsValue<TypeName, FieldName>,
+  context: GetGen<"context">,
+  info: GraphQLResolveInfo
+) => MaybePromise<boolean | Error>;
+
 export type AbstractResolveReturn<
   TypeName extends string
 > = NexusGen extends infer GenTypes


### PR DESCRIPTION
This PR is the beginning of an authorization strategy for GraphQL Nexus. Feedback welcome!

I added a field-level `authorize` method, but I'm not 100% convinced this should be the final solution here. Mainly wondering if there are things we can learn/adapt from graphql-ruby's approaches to [authorization](https://graphql-ruby.org/authorization/overview.html)? Their concepts of "[scoping](https://graphql-ruby.org/authorization/scoping.html)", "[authorization](https://graphql-ruby.org/authorization/authorization.html)", "[accessibility](https://graphql-ruby.org/authorization/accessibility.html)", and "[visibility](https://graphql-ruby.org/authorization/visibility.html)" are pretty interesting.

#### Goals:
- Covers all of the major use cases
- Type safety, as always
- Simplicity (as much as we can), the fewer concepts/codepaths the better

#### Questions:
- What are the major paths that folks would expect Nexus to reasonably cover? I don't mind building out a more robust layer around this, since it's a major pain-point when developing schemas.
- Should we be opinionated here and require an `authorize` property by default on "root type" fields (Query, Mutation, Subscription), with the ability to disable with `forceRootAuthorize: false` on the `makeSchema` config? Or maybe the other way around... opt in?
