### PR TITLE
Add t.resolveType() for defaultTypeResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 0.12.0 final (unreleased)
 
+- Partial fix for #188, allow `t.resolveType()` to use default `graphql-js` defaultTypeResolver for abstract types.
+
 ### 0.12.0-rc.4
 
 - refactor: Remove NEXUS_SHOULD_GENERATE_ARTIFACTS env var

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,8 +61,7 @@ import {
 const Node = interfaceType({
   name: "Node",
   definition(t) {
-    t.id("id", { description: "Unique identifier for the resource" });
-    t.resolveType(() => null);
+    t.resolveType();
   },
 });
 

--- a/examples/kitchen-sink/src/kitchen-sink-definitions.ts
+++ b/examples/kitchen-sink/src/kitchen-sink-definitions.ts
@@ -70,7 +70,7 @@ export const UnusedInterface = interfaceType({
   name: "UnusedInterface",
   definition(t) {
     t.boolean("ok");
-    t.resolveType(() => null);
+    t.resolveType();
   },
   rootTyping: { name: "UnusedInterfaceTypeDef", path: __filename },
 });

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -347,5 +347,5 @@ export class InputDefinitionBlock<TypeName extends string> {
 
 export interface AbstractOutputDefinitionBuilder<TypeName extends string>
   extends OutputDefinitionBuilder {
-  setResolveType(fn: AbstractTypeResolver<TypeName>): void;
+  setResolveType(fn: AbstractTypeResolver<TypeName> | null): void;
 }

--- a/src/definitions/interfaceType.ts
+++ b/src/definitions/interfaceType.ts
@@ -50,8 +50,8 @@ export class InterfaceDefinitionBlock<
   /**
    * Sets the "resolveType" method for the current type.
    */
-  resolveType(fn: AbstractTypeResolver<TypeName>) {
-    this.typeBuilder.setResolveType(fn);
+  resolveType(fn?: AbstractTypeResolver<TypeName>) {
+    this.typeBuilder.setResolveType(fn || null);
   }
 }
 

--- a/src/definitions/unionType.ts
+++ b/src/definitions/unionType.ts
@@ -4,7 +4,7 @@ import { assertValidName } from "graphql";
 import { NexusObjectTypeDef } from "./objectType";
 
 export interface UnionDefinitionBuilder<TypeName extends string> {
-  setResolveType(fn: AbstractTypeResolver<TypeName>): void;
+  setResolveType(fn: AbstractTypeResolver<TypeName> | null): void;
   addUnionMembers(members: UnionMembers): void;
 }
 
@@ -24,8 +24,8 @@ export class UnionDefinitionBlock<TypeName extends string> {
   /**
    * Sets the "resolveType" method for the current union
    */
-  resolveType(fn: AbstractTypeResolver<TypeName>) {
-    this.typeBuilder.setResolveType(fn);
+  resolveType(fn?: AbstractTypeResolver<TypeName>) {
+    this.typeBuilder.setResolveType(fn || null);
   }
 }
 

--- a/src/sdlConverter.ts
+++ b/src/sdlConverter.ts
@@ -285,7 +285,7 @@ export class SDLConverter {
       this.maybeDescription(type),
       `  definition(t) {`,
       this.printObjectFields(type),
-      `    t.resolveType(() => null)`,
+      `    t.resolveType()`,
       `  }`,
       `});`,
     ]);

--- a/tests/__snapshots__/interfaceType.spec.ts.snap
+++ b/tests/__snapshots__/interfaceType.spec.ts.snap
@@ -13,6 +13,6 @@ Object {
 
 exports[`interfaceType logs error when resolveType is not provided for an interface 1`] = `
 Array [
-  [Error: Missing resolveType for the Node union. Be sure to add one in the definition block for the type, or t.resolveType(() => null) if you don't want or need to implement.],
+  [Error: Missing resolveType for the Node union. Be sure to add one in the definition block for the type, or t.resolveType() if you want to use GraphQL's defaultTypeResolver and hide this warning.],
 ]
 `;

--- a/tests/__snapshots__/sdlConverter.spec.ts.snap
+++ b/tests/__snapshots__/sdlConverter.spec.ts.snap
@@ -189,7 +189,7 @@ export const Node = interfaceType({
   description: \\"This is a description of a Node\\",
   definition(t) {
     t.id(\\"id\\")
-    t.resolveType(() => null)
+    t.resolveType()
   }
 });
 
@@ -332,7 +332,7 @@ const Node = interfaceType({
   description: \\"This is a description of a Node\\",
   definition(t) {
     t.id(\\"id\\")
-    t.resolveType(() => null)
+    t.resolveType()
   }
 });
 

--- a/tests/interfaceType.spec.ts
+++ b/tests/interfaceType.spec.ts
@@ -10,7 +10,7 @@ describe("interfaceType", () => {
           name: "Node",
           definition(t) {
             t.id("id");
-            t.resolveType(() => null);
+            t.resolveType();
           },
         }),
         objectType({

--- a/tests/plugins/nullabilityGuardPlugin.spec.ts
+++ b/tests/plugins/nullabilityGuardPlugin.spec.ts
@@ -49,7 +49,7 @@ const types = [
     definition(t) {
       t.id("id");
       t.string("login");
-      t.resolveType((o) => o.__typename || null);
+      t.resolveType();
     },
   }),
   objectType({

--- a/website/playground/index.tsx
+++ b/website/playground/index.tsx
@@ -51,7 +51,7 @@ const content = dedent`
     definition(t) {
       t.date('createdAt', () => new Date());
       t.date('updatedAt', () => new Date());
-      t.resolveType(() => null)
+      t.resolveType();
     }
   });
 
@@ -65,7 +65,7 @@ const content = dedent`
           return ${"`${info.parentType.name}:${root.id}`"}
         }
       });
-      t.resolveType(() => null)
+      t.resolveType();
     }
   })
 


### PR DESCRIPTION
Related to #188 - allows `t.resolveType()` (no args) to be used to indicate that we should use the `defaultTypeResolver` from `graphql-js` and suppress the warning.