### PR TITLE
fix: typegen stable path generation with Windows

### DIFF
--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -170,7 +170,9 @@ export class TypegenPrinter {
         const importPath = (path.isAbsolute(val.path)
           ? relativePathTo(val.path, outputPath)
           : val.path
-        ).replace(/(\.d)?\.ts/, "");
+        )
+        .replace(/(\.d)?\.ts/, "")
+        .replace(/\\/, "/");
         importMap[importPath] = importMap[importPath] || new Set();
         importMap[importPath].add(
           val.alias ? `${val.name} as ${val.alias}` : val.name

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -172,7 +172,7 @@ export class TypegenPrinter {
           : val.path
         )
         .replace(/(\.d)?\.ts/, "")
-        .replace(/\\/, "/");
+        .replace(/\\+/g, "/");
         importMap[importPath] = importMap[importPath] || new Set();
         importMap[importPath].add(
           val.alias ? `${val.name} as ${val.alias}` : val.name


### PR DESCRIPTION
When using Windows, rootTypings paths are using `\` instead of `/` in generated code. This commit fixes it.