### PR TITLE
feat: make `queryType` and `mutationType` merge when called several times

### DIFF
--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -10,7 +10,7 @@ import {
 } from "../typegenTypeHelpers";
 import { ArgsRecord } from "./args";
 import { AllNexusInputTypeDefs, AllNexusOutputTypeDefs } from "./wrapping";
-import { BaseScalars } from "./_types";
+import { BaseScalars, NonNullConfig } from "./_types";
 
 export interface CommonFieldConfig {
   /**
@@ -69,6 +69,9 @@ export interface NexusOutputFieldConfig<
 export type NexusOutputFieldDef = NexusOutputFieldConfig<string, any> & {
   name: string;
   subscribe?: GraphQLFieldResolver<any, any>;
+  typeConfig?: {
+    nonNullDefaults?: NonNullConfig;
+  };
 };
 
 /**

--- a/src/definitions/extendType.ts
+++ b/src/definitions/extendType.ts
@@ -1,11 +1,22 @@
 import { assertValidName } from "graphql";
 import { AllOutputTypesPossible } from "../typegenTypeHelpers";
 import { OutputDefinitionBlock } from "./definitionBlocks";
-import { NexusTypes, withNexusSymbol } from "./_types";
+import { NexusTypes, withNexusSymbol, NonNullConfig } from "./_types";
 
 export interface NexusExtendTypeConfig<TypeName extends string> {
   type: TypeName;
   definition(t: OutputDefinitionBlock<TypeName>): void;
+  /**
+   * Configures the nullability for the type, check the
+   * documentation's "Getting Started" section to learn
+   * more about GraphQL Nexus's assumptions and configuration
+   * on nullability.
+   */
+  nonNullDefaults?: NonNullConfig;
+  /**
+   * The description to annotate the GraphQL SDL
+   */
+  description?: string | null;
 }
 
 export class NexusExtendTypeDef<TypeName extends string> {

--- a/src/definitions/objectType.ts
+++ b/src/definitions/objectType.ts
@@ -4,6 +4,7 @@ import {
   OutputDefinitionBlock,
   OutputDefinitionBuilder,
 } from "./definitionBlocks";
+import { extendType } from "./extendType";
 import { NexusInterfaceTypeDef } from "./interfaceType";
 import {
   NexusTypes,
@@ -105,13 +106,13 @@ export function objectType<TypeName extends string>(
 }
 
 export function queryType(
-  config: Omit<NexusObjectTypeConfig<"Query">, "name">
+  config: Omit<NexusObjectTypeConfig<"Query">, "name" | "rootTyping">
 ) {
-  return objectType({ ...config, name: "Query" });
+  return extendType({ ...config, type: "Query" });
 }
 
 export function mutationType(
-  config: Omit<NexusObjectTypeConfig<"Mutation">, "name">
+  config: Omit<NexusObjectTypeConfig<"Mutation">, "name" | "rootTyping">
 ) {
-  return objectType({ ...config, name: "Mutation" });
+  return extendType({ ...config, type: "Mutation" });
 }


### PR DESCRIPTION
## Description

- Make `extendType` accept `description` and `nonNullDefaults`.
	- `nonNullDefaults` stays local to the `extendType` instance
    - If several `description` are passed, they joined with a `\n`
- Make `queryType` and `mutationType` use `extendType` so that when called multiple times, types are merged.

## Problems

- There's no way anymore to have one `nonNullDefaults` configuration for all `queryType` and `mutationType` extensions (as they all have their own `NonNullConfig`). The only way is to first use `objectType({ name: 'Query', nonNullDefaults: { /* ... */ } })` which kinda sucks :/

## TODO

- Figure out what broke on tests
- Looks like `extendType` of interfaces is broken, even on `develop`