### PR TITLE
feat: support typescript 3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.6"
   },
   "peerDependencies": {
     "graphql": "^14.5.0"

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -762,7 +762,11 @@ export function makeResolveFn(
           ]).then(([edges, nodes]) => ({ edges, nodes }));
         }
 
-        return { nodes: resolvedNodeList, edges: resolvedEdgeList };
+        return {
+          nodes: resolvedNodeList,
+          // todo find typesafe way of doing this
+          edges: resolvedEdgeList as EdgeLike[],
+        };
       });
 
       return cachedEdges;

--- a/tests/plugins/nullabilityGuardPlugin.spec.ts
+++ b/tests/plugins/nullabilityGuardPlugin.spec.ts
@@ -148,7 +148,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.getUserWithGuard).toEqual({ id: "User:N/A" });
+    expect(data!.getUserWithGuard).toEqual({ id: "User:N/A" });
     expect(onGuardedMock).toBeCalledTimes(1);
   });
 
@@ -162,7 +162,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.intList).toEqual([1, 2, -1]);
+    expect(data!.intList).toEqual([1, 2, -1]);
     expect(onGuardedMock).toBeCalledTimes(1);
   });
 
@@ -178,7 +178,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.userList).toEqual([
+    expect(data!.userList).toEqual([
       { id: "User:N/A" },
       { id: "User:N/A" },
       { id: "User:N/A" },
@@ -199,7 +199,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.objType).toEqual({ id: "SomeObjectType:N/A" });
+    expect(data!.objType).toEqual({ id: "SomeObjectType:N/A" });
     expect(onGuardedMock).toBeCalledTimes(1);
   });
 
@@ -222,7 +222,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.interfaceType).toEqual({
+    expect(data!.interfaceType).toEqual({
       __typename: "User",
       id: "User:N/A",
       login: "",
@@ -267,7 +267,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.unionType).toEqual({
+    expect(data!.unionType).toEqual({
       __typename: "User",
       id: "User:N/A",
       login: "",
@@ -289,7 +289,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.enumType).toEqual("A");
+    expect(data!.enumType).toEqual("A");
     expect(onGuardedMock).toBeCalledTimes(1);
   });
 
@@ -313,7 +313,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toEqual([]);
-    expect(data.getUserWithGuard).toEqual({ id: "User:N/A" });
+    expect(data!.getUserWithGuard).toEqual({ id: "User:N/A" });
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
       "Nullability guard called for User.id"
@@ -356,7 +356,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors2).toEqual([]);
-    expect(data2.getUserWithGuard).toEqual({ id: "User:N/A" });
+    expect(data2!.getUserWithGuard).toEqual({ id: "User:N/A" });
   });
 
   it("logs an error if scalars are missing", () => {
@@ -435,7 +435,7 @@ describe("nullabilityGuardPlugin", () => {
       `
     );
     expect(errors).toHaveLength(0);
-    expect(data.nullableList).toEqual(null);
+    expect(data!.nullableList).toEqual(null);
     expect(onGuardedMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5456,10 +5456,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
One internal type error was raised with 3.9 that wasn't before.

This might have led to end-users having to enable `skipLibCheck`?

For my doubt on this, I'm leaning toward this being a feature, rather than just a chore.