### PR TITLE
Fix MaybePromiseDeep for arrays

### DIFF
--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -41,6 +41,10 @@ export type MaybePromiseDeep<T> = Date extends T
   ? MaybePromise<T>
   : string extends T
   ? MaybePromise<T>
+  : T extends Array<infer X>
+  ? MaybePromise<Array<X>>
+  : T extends ReadonlyArray<infer Z>
+  ? MaybePromise<ReadonlyArray<Z>>
   : T extends object
   ? MaybePromise<
       | T


### PR DESCRIPTION
## Goal
- Allow `MaybePromiseDeep` to work with promises with a then returning an array but where the definition allows for null

## Documentation
Use this [playground](https://www.typescriptlang.org/play/?ssl=22&ssc=35&pln=19&pc=1#code/C4TwDgpgBAKhDOwoF4oG8BQVtQJYBMAuKAOwFcBbAIwgCcMBfDDAYwHsTEoBzXANwhxE8FFACG8ECRZQAFAEpiABVpsKueBAA8Q4AG0AugD4UJzDii0IwMrRJRDjZqEhQAsmJA0VajdpgmqD7qmgAyuADW-iYAPrAA3M7g0B5eEMF+ACIQEGA6gVCZYsDQEAAeJST4IjBYUAD87p7eqiHRdcRUbGwANhBi9uWV1bB1jaktvpr5HaSUNLRQQxBVNWNNaRnTAbOItLgk3EsVKyO12OPN6a1+M9jEMMfDIgCCtLSeWgcAZnRQAKpGdYTa5TbRvD4gLSAoH3WBPU4iABK-XwHB6IAhnx+f0BwKuW20KLEaJIGKxUJhs0ey1WUDYVAAVhAWMB8ZsbtM6hY4ucLFA4uZ+RY9Eo8PYoiA2N9YAYHqKDAi6RSviRfos8cLhZcOWCtCqQYTsrloUYzdytXCYAqlSNiaTye9sWq-gBNWGWnA6yZtLT29GYp1Qw2ciDGvLu82enDEENg8M6BUe4VMCwe2ME0MzDAuaAo+BkHpIVC6QwCuY9HrMVgcLhiYgKUwbH23fOF4CxZugtoJttFgqN5AmXgCXTwBQAOmAAAsVrJZCVhE3F8B4PJ5PEgA) to see the problem. If you remove lines 19-22 it will show an error.

## References
Fixes #470 