### PR TITLE
docs: update asNexusMethod example with the changes from #473

### DIFF
--- a/docs/api-scalarType.md
+++ b/docs/api-scalarType.md
@@ -51,7 +51,7 @@ If you have an existing GraphQL scalar and you'd like to expose it as a method o
 ```ts
 import { GraphQLDate } from "graphql-iso-date";
 
-export const GQLDate = asNexusMethod(GraphQLDate, "date");
+export const GQLDate = asNexusMethod(GraphQLDate, "date", "Date");
 ```
 
 ```ts


### PR DESCRIPTION
The problem in #360 was the missing documentation on how to do it. Now that it's even easier with #473 so this PR updates the docs with an example.