### PR TITLE
fix: message for missing resolveType in interfaces

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -841,7 +841,7 @@ export class SchemaBuilder {
       })
     }
     if (!resolveType) {
-      resolveType = this.missingResolveType(config.name, 'union')
+      resolveType = this.missingResolveType(config.name, 'interface')
     }
     if (config.rootTyping) {
       this.rootTypings[config.name] = config.rootTyping

--- a/tests/__snapshots__/interfaceType.spec.ts.snap
+++ b/tests/__snapshots__/interfaceType.spec.ts.snap
@@ -13,6 +13,6 @@ Object {
 
 exports[`interfaceType logs error when resolveType is not provided for an interface 1`] = `
 Array [
-  [Error: Missing resolveType for the Node union. Be sure to add one in the definition block for the type, or t.resolveType(() => null) if you don't want or need to implement.],
+  [Error: Missing resolveType for the Node interface. Be sure to add one in the definition block for the type, or t.resolveType(() => null) if you don't want or need to implement.],
 ]
 `;


### PR DESCRIPTION
This fixes a small mistake in the error message shown when `resolveType` hasn't been defined on an interfaceType.