### PR TITLE
temp: Temporary redirects for old nexus.js.org

### DIFF
--- a/tmp/_redirects
+++ b/tmp/_redirects
@@ -1,0 +1,1 @@
+https://nexus.js.org/* https://nexusjs.org/:splat 301!


### PR DESCRIPTION
This will serve as a temporary deploy folder for the old nexus.js.org until the DNS has been updated.