### PR TITLE
docs: Fix ts-node-dev flag in the docs

### DIFF
--- a/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
+++ b/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
@@ -44,7 +44,7 @@ You will need to manage running and restarting your server on changes during dev
 ```tsx
 {
   "scripts": {
-    "dev": "ts-node-dev --transpileOnly ./your/main/module",
+    "dev": "ts-node-dev --transpile-only ./your/main/module",
     "dev:typecheck": "tsc --noEmit --watch",
   }
 }


### PR DESCRIPTION
It has been renamed: https://github.com/whitecolor/ts-node-dev/issues/186