### PR TITLE
chore(docs): Fix a typo in 030-neuxs-framework-prisma-users.mdx

### DIFF
--- a/docs/content/040-adoption-guides/030-neuxs-framework-prisma-users.mdx
+++ b/docs/content/040-adoption-guides/030-neuxs-framework-prisma-users.mdx
@@ -17,7 +17,7 @@ npm add -D @prisma/cli
 npm add @prisma/client
 ```
 
-You must also make sure that you are using the version `0.30` or later of `nexus-prisma-plugin`.
+You must also make sure that you are using the version `0.20.0` or later of `nexus-plugin-prisma`.
 
 ## Enabling the plugin
 


### PR DESCRIPTION
typo with `nexus-plugin-prisma` and version `0.20.0` instead of `0.30`