### PR TITLE
fix: error if root typing path is invalid

### DIFF
--- a/src/typegenAutoConfig.ts
+++ b/src/typegenAutoConfig.ts
@@ -18,7 +18,7 @@ export const SCALAR_TYPES = {
 export interface TypegenConfigSourceModule {
   /**
    * The module for where to look for the types.
-   * This uses the node resolution algorthm via require.resolve,
+   * This uses the node resolution algorithm via require.resolve,
    * so if this lives in node_modules, you can just provide the module name
    * otherwise you should provide the absolute path to the file.
    */

--- a/tests/backingTypes.spec.ts
+++ b/tests/backingTypes.spec.ts
@@ -170,8 +170,12 @@ describe('rootTypings', () => {
       typegenFile: '',
     })
 
-    expect(() => typegen.print()).toThrowErrorMatchingInlineSnapshot(
-      `"Root typing path /Users/flavian/projects/prisma/nexus-schema/tests/invalid_path.ts of the type SomeType does not exist"`
-    )
+    try {
+      typegen.print()
+    } catch (e) {
+      expect(e.message.replace(__dirname, '')).toMatchInlineSnapshot(
+        `"Root typing path /invalid_path.ts of the type SomeType does not exist"`
+      )
+    }
   })
 })

--- a/tests/backingTypes.spec.ts
+++ b/tests/backingTypes.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { core, enumType, makeSchema, queryType } from '..'
+import { core, enumType, makeSchema, objectType, queryType } from '..'
 import { A, B } from './_types'
 
 const { TypegenPrinter, TypegenMetadata } = core
@@ -111,5 +111,67 @@ describe('rootTypings', () => {
       typegenFile: '',
     })
     expect(typegen.print()).toMatchSnapshot()
+  })
+
+  it('throws error if root typing path is not an absolute path', async () => {
+    const metadata = new TypegenMetadata({
+      outputs: { typegen: false, schema: false },
+    })
+    const someType = objectType({
+      name: 'SomeType',
+      rootTyping: {
+        name: 'invalid',
+        path: 'fzeffezpokm',
+      },
+      definition(t) {
+        t.id('id')
+      },
+    })
+
+    const schema = makeSchema({
+      types: [someType],
+      outputs: false,
+    })
+
+    const typegenInfo = await metadata.getTypegenInfo(schema)
+    const typegen = new TypegenPrinter(schema, {
+      ...typegenInfo,
+      typegenFile: '',
+    })
+
+    expect(() => typegen.print()).toThrowErrorMatchingInlineSnapshot(
+      `"Expected an absolute path for the root typing path of the type SomeType, saw fzeffezpokm"`
+    )
+  })
+
+  it('throws error if root typing path does not exist', async () => {
+    const metadata = new TypegenMetadata({
+      outputs: { typegen: false, schema: false },
+    })
+    const someType = objectType({
+      name: 'SomeType',
+      rootTyping: {
+        name: 'invalid',
+        path: __dirname + '/invalid_path.ts',
+      },
+      definition(t) {
+        t.id('id')
+      },
+    })
+
+    const schema = makeSchema({
+      types: [someType],
+      outputs: false,
+    })
+
+    const typegenInfo = await metadata.getTypegenInfo(schema)
+    const typegen = new TypegenPrinter(schema, {
+      ...typegenInfo,
+      typegenFile: '',
+    })
+
+    expect(() => typegen.print()).toThrowErrorMatchingInlineSnapshot(
+      `"Root typing path /Users/flavian/projects/prisma/nexus-schema/tests/invalid_path.ts of the type SomeType does not exist"`
+    )
   })
 })


### PR DESCRIPTION
Closes #396

We unfortunately cannot add a runtime error if the type that's imported from the path does not exist without substantial work and/or performance overhead.

If we use the current regex approach, we might end up throwing in cases where the type is properly exported but the regex fails to see that.

The only approach would be to parse the actual file with the type-checker, which is way out of scope for this PR.