### PR TITLE
fix: subscription type static typings

### DIFF
--- a/examples/zeit-typescript/package.json
+++ b/examples/zeit-typescript/package.json
@@ -13,7 +13,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@nexus/schema": "^0.16.0",
+    "@nexus/schema": "0.17.0-next.2",
     "graphql": "^15.3.0"
   },
   "devDependencies": {

--- a/examples/zeit-typescript/yarn.lock
+++ b/examples/zeit-typescript/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@nexus/schema@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@nexus/schema/-/schema-0.16.0.tgz#cbf2b70eb47a854e4bcec849583368d7e7048087"
-  integrity sha512-H+JJDycjcilvsRtLySpwfVXp1gYiOqPPLQdq04R4Vp5S400PpdADQlKMV4EvpBJ/BCxwQ8XwP8+nrOKvDZLLUw==
+"@nexus/schema@0.17.0-next.2":
+  version "0.17.0-next.2"
+  resolved "https://registry.yarnpkg.com/@nexus/schema/-/schema-0.17.0-next.2.tgz#b85fcb1cd35d4fd65618404f406d0e1e309ffda7"
+  integrity sha512-EMUYhEvo6DkbZSBC/ErlSN59KWDVrZbuBbRY+QbRn2EsOcOhA3Y6g+/SDYEfJwqJzKjiC9AjqOmOqzmBXBNJQA==
   dependencies:
     iterall "^1.2.2"
     tslib "^1.9.3"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,21 +1,18 @@
-const path = require("path");
+const path = require('path')
 
 /**
  * @type {jest.InitialOptions}
  */
 module.exports = {
-  setupFilesAfterEnv: ["<rootDir>/tests/_setup.ts"],
-  preset: "ts-jest",
-  testEnvironment: "node",
-  watchPlugins: [
-    "jest-watch-typeahead/filename",
-    "jest-watch-typeahead/testname",
-  ],
+  setupFilesAfterEnv: ['<rootDir>/tests/_setup.ts'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
   globals: {
-    "ts-jest": {
+    'ts-jest': {
       diagnostics: true, // (temp) true
-      tsConfig: path.join(__dirname, "tests/tsconfig.json"),
+      tsConfig: path.join(__dirname, 'tests/tsconfig.json'),
     },
   },
-  collectCoverageFrom: ["src/**/*"],
-};
+  collectCoverageFrom: ['src/**/*'],
+}

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -106,9 +106,11 @@ export interface InputDefinitionBuilder {
   warn(msg: string): void
 }
 
+// prettier-ignore
 export interface OutputDefinitionBlock<TypeName extends string>
-  extends NexusGenCustomOutputMethods<TypeName>,
-    NexusGenCustomOutputProperties<TypeName> {}
+       extends NexusGenCustomOutputMethods<TypeName>,
+               NexusGenCustomOutputProperties<TypeName>
+       {}
 
 /**
  * The output definition block is passed to the "definition"

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -64,28 +64,24 @@ export type NexusOutputFieldDef = NexusOutputFieldConfig<string, any> & {
   subscribe?: GraphQLFieldResolver<any, any>
 }
 
-/**
- * Ensure type-safety by checking
- */
-export type ScalarOutSpread<TypeName extends string, FieldName extends string> = NeedsResolver<
-  TypeName,
-  FieldName
-> extends true
-  ? HasGen3<'argTypes', TypeName, FieldName> extends true
-    ? [ScalarOutConfig<TypeName, FieldName>]
-    : [ScalarOutConfig<TypeName, FieldName>] | [FieldResolver<TypeName, FieldName>]
-  : HasGen3<'argTypes', TypeName, FieldName> extends true
-  ? [ScalarOutConfig<TypeName, FieldName>]
-  : [] | [FieldResolver<TypeName, FieldName>] | [ScalarOutConfig<TypeName, FieldName>]
+// prettier-ignore
+export type ScalarOutSpread<TypeName extends string, FieldName extends string> =
+  NeedsResolver<TypeName, FieldName> extends true
+    ? HasGen3<'argTypes', TypeName, FieldName> extends true
+      ? [ScalarOutConfig<TypeName, FieldName>]
+      : [ScalarOutConfig<TypeName, FieldName>] | [FieldResolver<TypeName, FieldName>]
+    : HasGen3<'argTypes', TypeName, FieldName> extends true
+      ? [ScalarOutConfig<TypeName, FieldName>]
+      : [] | [FieldResolver<TypeName, FieldName>] | [ScalarOutConfig<TypeName, FieldName>]
 
-export type ScalarOutConfig<TypeName extends string, FieldName extends string> = NeedsResolver<
-  TypeName,
-  FieldName
-> extends true
-  ? OutputScalarConfig<TypeName, FieldName> & {
-      resolve: FieldResolver<TypeName, FieldName>
-    }
-  : OutputScalarConfig<TypeName, FieldName>
+// prettier-ignore
+export type ScalarOutConfig<TypeName extends string, FieldName extends string> =
+    NeedsResolver<TypeName, FieldName> extends true
+    ? OutputScalarConfig<TypeName, FieldName> &
+      {
+        resolve: FieldResolver<TypeName, FieldName>
+      }
+    : OutputScalarConfig<TypeName, FieldName>
 
 export type FieldOutConfig<TypeName extends string, FieldName extends string> = NeedsResolver<
   TypeName,
@@ -158,8 +154,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
     // 2. NexusOutputFieldDef is contrained to be be a string
     // 3. so `name` is not compatible
     // 4. and changing FieldOutConfig to FieldOutConfig<string breaks types in other places
-    const field: any = { name, ...fieldConfig }
-    this.typeBuilder.addField(this.decorateField(field))
+    this.typeBuilder.addField(this.decorateField({ name, ...fieldConfig } as any))
   }
 
   protected addScalarField(

--- a/src/definitions/extendType.ts
+++ b/src/definitions/extendType.ts
@@ -1,13 +1,13 @@
 import { assertValidName } from 'graphql'
 import { AllOutputTypesPossible } from '../typegenTypeHelpers'
 import { OutputDefinitionBlock } from './definitionBlocks'
-import { IsSubscriptionType, SubscriptionBuilder } from './subscriptionType'
 import { NexusTypes, withNexusSymbol } from './_types'
 
 export interface NexusExtendTypeConfig<TypeName extends string> {
   type: TypeName
   definition(
-    t: IsSubscriptionType<TypeName> extends true ? SubscriptionBuilder : OutputDefinitionBlock<TypeName>
+    // t: IsSubscriptionType<TypeName> extends true ? SubscriptionBuilder : OutputDefinitionBlock<TypeName>
+    t: OutputDefinitionBlock<TypeName>
   ): void
 }
 

--- a/src/definitions/extendType.ts
+++ b/src/definitions/extendType.ts
@@ -1,11 +1,14 @@
 import { assertValidName } from 'graphql'
 import { AllOutputTypesPossible } from '../typegenTypeHelpers'
 import { OutputDefinitionBlock } from './definitionBlocks'
+import { IsSubscriptionType, SubscriptionBuilder } from './subscriptionType'
 import { NexusTypes, withNexusSymbol } from './_types'
 
 export interface NexusExtendTypeConfig<TypeName extends string> {
   type: TypeName
-  definition(t: OutputDefinitionBlock<TypeName>): void
+  definition(
+    t: IsSubscriptionType<TypeName> extends true ? SubscriptionBuilder : OutputDefinitionBlock<TypeName>
+  ): void
 }
 
 export class NexusExtendTypeDef<TypeName extends string> {

--- a/src/definitions/subscriptionField.ts
+++ b/src/definitions/subscriptionField.ts
@@ -14,7 +14,7 @@ export function subscriptionField<FieldName extends string>(
     type: 'Subscription',
     definition(t) {
       const finalConfig = typeof config === 'function' ? config() : config
-      t.field(fieldName, finalConfig as any)
+      t.field(fieldName, finalConfig)
     },
   })
 }

--- a/src/definitions/subscriptionField.ts
+++ b/src/definitions/subscriptionField.ts
@@ -14,7 +14,7 @@ export function subscriptionField<FieldName extends string>(
     type: 'Subscription',
     definition(t) {
       const finalConfig = typeof config === 'function' ? config() : config
-      t.field(fieldName, finalConfig)
+      t.field(fieldName, finalConfig as any)
     },
   })
 }

--- a/src/definitions/subscriptionType.ts
+++ b/src/definitions/subscriptionType.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql'
 import { ArgsValue, GetGen, MaybePromise, MaybePromiseDeep, ResultValue } from '../typegenTypeHelpers'
+import { IsEqual } from '../utils'
 import { CommonOutputFieldConfig, NexusOutputFieldDef } from './definitionBlocks'
 import { ObjectDefinitionBuilder, objectType } from './objectType'
 import { AllNexusOutputTypeDefs } from './wrapping'
@@ -106,3 +107,5 @@ export type SubscriptionTypeParams = {
 export function subscriptionType(config: SubscriptionTypeParams) {
   return objectType({ name: 'Subscription', ...config } as any)
 }
+
+export type IsSubscriptionType<T> = IsEqual<T, 'Subscription'>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -415,3 +415,8 @@ export function getOwnPackage(): { name: string } {
 export function casesHandled(x: never): never {
   throw new Error(`A case was not handled for value: ${x}`)
 }
+
+/**
+ * Is the given type equal to the other given type?
+ */
+export type IsEqual<A, B> = A extends B ? (B extends A ? true : false) : false

--- a/tests/integration/_app.ts
+++ b/tests/integration/_app.ts
@@ -9,7 +9,9 @@ import {
   objectType,
   queryType,
   stringArg,
+  subscriptionType,
 } from '../../src'
+import { mockStream } from '../_helpers'
 import './_app.typegen'
 
 export const query = queryType({
@@ -93,6 +95,61 @@ export const Mutation = mutationType({
       type: 'User',
       args: { firstName: stringArg(), lastName: stringArg() },
       resolve: (_root) => ({ firstName: '', lastName: '' }),
+    })
+  },
+})
+
+export const Subscription = subscriptionType({
+  definition(t) {
+    //todo .list case
+    t.field('someField', {
+      type: 'Int',
+      subscribe() {
+        return mockStream(10, 0, (int) => int - 1)
+      },
+      resolve: (event) => {
+        return event
+      },
+    })
+    t.int('someInt', {
+      subscribe() {
+        return mockStream(10, 0, (int) => int + 1)
+      },
+      resolve: (event) => {
+        return event
+      },
+    })
+    t.string('someString', {
+      subscribe() {
+        return mockStream(10, '', (str) => str + '!')
+      },
+      resolve: (event) => {
+        return event
+      },
+    })
+    t.float('someFloat', {
+      subscribe() {
+        return mockStream(10, 0.5, (f) => f)
+      },
+      resolve: (event) => {
+        return event
+      },
+    })
+    t.boolean('someBoolean', {
+      subscribe() {
+        return mockStream(10, true, (b) => b)
+      },
+      resolve: (event) => {
+        return event
+      },
+    })
+    t.id('someID', {
+      subscribe() {
+        return mockStream(10, 'abc', (id) => id)
+      },
+      resolve: (event) => {
+        return event
+      },
     })
   },
 })

--- a/tests/integration/_app.ts
+++ b/tests/integration/_app.ts
@@ -101,7 +101,25 @@ export const Mutation = mutationType({
 
 export const Subscription = subscriptionType({
   definition(t) {
-    //todo .list case
+    // lists
+    t.list.field('someFields', {
+      type: 'Int',
+      subscribe() {
+        return mockStream(10, 0, (int) => int - 1)
+      },
+      resolve: (event) => {
+        return event
+      },
+    })
+    t.list.int('someInts', {
+      subscribe() {
+        return mockStream(10, 0, (int) => int + 1)
+      },
+      resolve: (event) => {
+        return event
+      },
+    })
+    // singular
     t.field('someField', {
       type: 'Int',
       subscribe() {

--- a/tests/integration/_app.typegen.ts
+++ b/tests/integration/_app.typegen.ts
@@ -50,6 +50,7 @@ export interface NexusGenRootTypes {
     title?: string | null // String
   }
   Query: {}
+  Subscription: {}
   User: { firstName: string; lastName: string }
 }
 
@@ -77,6 +78,15 @@ export interface NexusGenFieldTypes {
     foo: string | null // String
     searchPosts: Array<NexusGenRootTypes['Post'] | null> | null // [Post]
     user: NexusGenRootTypes['User'] | null // User
+  }
+  Subscription: {
+    // field return type
+    someBoolean: boolean | null // Boolean
+    someField: number | null // Int
+    someFloat: number | null // Float
+    someID: string | null // ID
+    someInt: number | null // Int
+    someString: string | null // String
   }
   User: {
     // field return type
@@ -109,7 +119,7 @@ export interface NexusGenAbstractResolveReturnTypes {}
 
 export interface NexusGenInheritedFields {}
 
-export type NexusGenObjectNames = 'Mutation' | 'Post' | 'Query' | 'User'
+export type NexusGenObjectNames = 'Mutation' | 'Post' | 'Query' | 'Subscription' | 'User'
 
 export type NexusGenInputNames = 'PostSearchInput'
 

--- a/tests/integration/_app.typegen.ts
+++ b/tests/integration/_app.typegen.ts
@@ -83,9 +83,11 @@ export interface NexusGenFieldTypes {
     // field return type
     someBoolean: boolean | null // Boolean
     someField: number | null // Int
+    someFields: Array<number | null> | null // [Int]
     someFloat: number | null // Float
     someID: string | null // ID
     someInt: number | null // Int
+    someInts: Array<number | null> | null // [Int]
     someString: string | null // String
   }
   User: {

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -1,5 +1,5 @@
-import { buildSchema, graphql, GraphQLSchema, printSchema, introspectionFromSchema } from 'graphql'
-import { makeSchema, MiddlewareFn, objectType, plugin, queryField, interfaceType } from '../src/core'
+import { buildSchema, graphql, GraphQLSchema, printSchema } from 'graphql'
+import { interfaceType, makeSchema, MiddlewareFn, objectType, plugin, queryField } from '../src/core'
 import { nullabilityGuardPlugin } from '../src/plugins'
 import { EXAMPLE_SDL } from './_sdl'
 
@@ -126,7 +126,7 @@ describe('plugin', () => {
             if (!exec) {
               return null
             }
-            const [match, typeName, fieldType] = exec
+            const [, typeName, fieldType] = exec
             switch (fieldType) {
               case 'Edge': {
                 return objectType({

--- a/tests/plugins/nullabilityGuardPlugin.spec.ts
+++ b/tests/plugins/nullabilityGuardPlugin.spec.ts
@@ -398,7 +398,7 @@ describe('nullabilityGuardPlugin', () => {
   })
 
   it('will still fail if it cant handle with a guard', async () => {
-    const { errors = [], data } = await graphql(
+    const { errors = [] } = await graphql(
       defaultSchema,
       `
         {

--- a/tests/plugins/queryComplexityPlugin.spec.ts
+++ b/tests/plugins/queryComplexityPlugin.spec.ts
@@ -88,7 +88,7 @@ describe('queryComplexityPlugin', () => {
   })
 
   test('throws error if complexity is of invalid type', () => {
-    const testSchema = createTestSchema([
+    createTestSchema([
       objectType({
         name: 'User',
         definition(t) {

--- a/tests/subscriptionType.spec.ts
+++ b/tests/subscriptionType.spec.ts
@@ -7,6 +7,7 @@ it('defines a field on the mutation type as shorthand', async () => {
     types: [
       subscriptionType({
         definition(t) {
+          //todo .list case
           t.field('someField', {
             type: 'Int',
             subscribe() {

--- a/tests/subscriptionType.spec.ts
+++ b/tests/subscriptionType.spec.ts
@@ -7,7 +7,25 @@ it('defines a field on the mutation type as shorthand', async () => {
     types: [
       subscriptionType({
         definition(t) {
-          //todo .list case
+          // lists
+          t.list.field('someFields', {
+            type: 'Int',
+            subscribe() {
+              return mockStream(10, 0, (int) => int - 1)
+            },
+            resolve: (event) => {
+              return event
+            },
+          })
+          t.list.int('someInts', {
+            subscribe() {
+              return mockStream(10, 0, (int) => int + 1)
+            },
+            resolve: (event) => {
+              return event
+            },
+          })
+          // singular
           t.field('someField', {
             type: 'Int',
             subscribe() {
@@ -65,6 +83,8 @@ it('defines a field on the mutation type as shorthand', async () => {
 
   expect(GQL.printSchema(schema)).toMatchInlineSnapshot(`
     "type Subscription {
+      someFields: [Int]
+      someInts: [Int]
       someField: Int
       someInt: Int
       someString: String


### PR DESCRIPTION
fixes #559

This takes another stab at implementing subscription type. It fixes multiple things.

- It no longer sub-classes from Object Type. This means we lose interface implements support. However this was never tested before and it is unclear its even a feature we want.
- It simplifies the field shorthand typings by removing the resolver shorthand param style. This style is unusable since subscribe config field is always needed anyways.
- It fixes field shorthand config which would fail when typegen was present. Specifically the subscribe field was not being recognized before.

Also

- It adds subscription type test cases to integration test. This way we capture the error that only happens when typegen is present.