### PR TITLE
Update code blocks in Chapter 6 of the tutorial to fix error

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
@@ -238,8 +238,8 @@ schema.extendType({
     t.field('createDraft', {
       type: 'Post',
       args: {
-        title: schema.stringArg({ required: true }),
-        body: schema.stringArg({ required: true }),
+        title: stringArg({ required: true }),
+        body: stringArg({ required: true }),
       },
       resolve(_root, args, ctx) {
         const draft = {
@@ -258,7 +258,7 @@ schema.extendType({
     t.field('publish', {
       type: 'Post',
       args: {
-        draftId: schema.intArg({ required: true }),
+        draftId: intArg({ required: true }),
       },
       resolve(_root, args, ctx) {
 -       let postToPublish = ctx.db.posts.find((p) => p.id === args.draftId)
@@ -316,8 +316,8 @@ schema.extendType({
     t.field('createDraft', {
       type: 'Post',
       args: {
-        title: schema.stringArg({ required: true }),
-        body: schema.stringArg({ required: true }),
+        title: stringArg({ required: true }),
+        body: stringArg({ required: true }),
       },
       resolve(_root, args, ctx) {
         const draft = {
@@ -332,7 +332,7 @@ schema.extendType({
     t.field('publish', {
       type: 'Post',
       args: {
-        draftId: schema.intArg({ required: true }),
+        draftId: intArg({ required: true }),
       },
       resolve(_root, args, ctx) {
         return ctx.db.post.update({


### PR DESCRIPTION
For the types in `args` there was `schema.<type>` in all the blocks of code which raises an error. However it should be `stringArg` and `intArg` rather than `schema.stringArg` and `schema.intArg`