### PR TITLE
fix: add deprecated & description to connectionField plugin

### DIFF
--- a/examples/apollo-fullstack/src/index.ts
+++ b/examples/apollo-fullstack/src/index.ts
@@ -26,7 +26,7 @@ const schema = makeSchema({
     ],
     contextType: 't.Context',
   },
-  prettierConfig: require.resolve('../../../package.json'),
+  prettierConfig: require.resolve('../../../.prettierrc'),
 })
 
 const store = createStore()

--- a/examples/ghost/src/ghost-schema.ts
+++ b/examples/ghost/src/ghost-schema.ts
@@ -26,5 +26,5 @@ export const schema = makeSchema({
       Date: 'Date',
     },
   },
-  prettierConfig: require.resolve('../../../package.json'),
+  prettierConfig: require.resolve('../../../.prettierrc'),
 })

--- a/examples/githunt-api/src/index.js
+++ b/examples/githunt-api/src/index.js
@@ -10,7 +10,7 @@ const schema = makeSchema({
     schema: path.join(__dirname, '../githunt-api-schema.graphql'),
     typegen: path.join(__dirname, './githunt-typegen.ts'),
   },
-  prettierConfig: require.resolve('../../../package.json'),
+  prettierConfig: require.resolve('../../../.prettierrc'),
 })
 
 const server = new ApolloServer({

--- a/examples/kitchen-sink/kitchen-sink-schema.graphql
+++ b/examples/kitchen-sink/kitchen-sink-schema.graphql
@@ -146,6 +146,27 @@ type Query {
   ): BooleanConnection
   complexQuery(count: Int!): [ComplexObject]
   dateAsList: [Date]
+  deprecatedConnection(
+    """
+    Returns the elements in the list that come after the specified cursor
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor
+    """
+    before: String
+
+    """
+    Returns the first n elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last n elements from the list.
+    """
+    last: Int
+  ): BooleanConnection @deprecated(reason: "Dont use this, use booleanConnection instead")
   extended: SomeItem
   getNumberOrNull(a: Int!): Int
   guardedConnection(
@@ -200,6 +221,10 @@ type Query {
     """
     first: Int!
   ): UserConnection
+
+  """
+  A connection with some user nodes
+  """
   usersConnectionNodes(
     """
     Returns the elements in the list that come after the specified cursor

--- a/examples/kitchen-sink/kitchen-sink-schema.graphql
+++ b/examples/kitchen-sink/kitchen-sink-schema.graphql
@@ -166,7 +166,7 @@ type Query {
     Returns the last n elements from the list.
     """
     last: Int
-  ): BooleanConnection @deprecated(reason: "Dont use this, use booleanConnection instead")
+  ): BooleanConnection! @deprecated(reason: "Dont use this, use booleanConnection instead")
   extended: SomeItem
   getNumberOrNull(a: Int!): Int
   guardedConnection(

--- a/examples/kitchen-sink/src/index.ts
+++ b/examples/kitchen-sink/src/index.ts
@@ -43,7 +43,7 @@ const schema = makeSchema({
       },
     }),
   ],
-  prettierConfig: require.resolve('../../../package.json'),
+  prettierConfig: require.resolve('../../../.prettierrc'),
 })
 
 const server = new ApolloServer({

--- a/examples/kitchen-sink/src/kitchen-sink-definitions.ts
+++ b/examples/kitchen-sink/src/kitchen-sink-definitions.ts
@@ -207,6 +207,7 @@ export const Query = objectType({
     t.connectionField('deprecatedConnection', {
       type: 'Boolean',
       deprecation: 'Dont use this, use booleanConnection instead',
+      nullable: false,
       nodes() {
         return [true]
       },

--- a/examples/kitchen-sink/src/kitchen-sink-definitions.ts
+++ b/examples/kitchen-sink/src/kitchen-sink-definitions.ts
@@ -204,6 +204,14 @@ export const Query = objectType({
       },
     })
 
+    t.connectionField('deprecatedConnection', {
+      type: 'Boolean',
+      deprecation: 'Dont use this, use booleanConnection instead',
+      nodes() {
+        return [true]
+      },
+    })
+
     t.connectionField('guardedConnection', {
       type: 'Date',
       disableBackwardPagination: true,
@@ -217,6 +225,7 @@ export const Query = objectType({
 
     t.connectionField('usersConnectionNodes', {
       type: User,
+      description: 'A connection with some user nodes',
       cursorFromNode(node, args, ctx, info, { index, nodes }) {
         if (args.last && !args.before) {
           const totalCount = USERS_DATA.length

--- a/examples/kitchen-sink/src/kitchen-sink.gen.ts
+++ b/examples/kitchen-sink/src/kitchen-sink.gen.ts
@@ -201,6 +201,7 @@ export interface NexusGenFieldTypes {
     booleanConnection: NexusGenRootTypes['BooleanConnection'] | null // BooleanConnection
     complexQuery: Array<NexusGenRootTypes['ComplexObject'] | null> | null // [ComplexObject]
     dateAsList: Array<NexusGenScalars['Date'] | null> | null // [Date]
+    deprecatedConnection: NexusGenRootTypes['BooleanConnection'] | null // BooleanConnection
     extended: NexusGenRootTypes['SomeItem'] | null // SomeItem
     getNumberOrNull: number | null // Int
     guardedConnection: NexusGenRootTypes['DateConnection'] | null // DateConnection
@@ -310,6 +311,7 @@ export interface NexusGenFieldTypeNames {
     booleanConnection: 'BooleanConnection'
     complexQuery: 'ComplexObject'
     dateAsList: 'Date'
+    deprecatedConnection: 'BooleanConnection'
     extended: 'SomeItem'
     getNumberOrNull: 'Int'
     guardedConnection: 'DateConnection'
@@ -395,6 +397,13 @@ export interface NexusGenArgTypes {
     complexQuery: {
       // args
       count: number // Int!
+    }
+    deprecatedConnection: {
+      // args
+      after?: string | null // String
+      before?: string | null // String
+      first?: number | null // Int
+      last?: number | null // Int
     }
     getNumberOrNull: {
       // args

--- a/examples/kitchen-sink/src/kitchen-sink.gen.ts
+++ b/examples/kitchen-sink/src/kitchen-sink.gen.ts
@@ -201,7 +201,7 @@ export interface NexusGenFieldTypes {
     booleanConnection: NexusGenRootTypes['BooleanConnection'] | null // BooleanConnection
     complexQuery: Array<NexusGenRootTypes['ComplexObject'] | null> | null // [ComplexObject]
     dateAsList: Array<NexusGenScalars['Date'] | null> | null // [Date]
-    deprecatedConnection: NexusGenRootTypes['BooleanConnection'] | null // BooleanConnection
+    deprecatedConnection: NexusGenRootTypes['BooleanConnection'] // BooleanConnection!
     extended: NexusGenRootTypes['SomeItem'] | null // SomeItem
     getNumberOrNull: number | null // Int
     guardedConnection: NexusGenRootTypes['DateConnection'] | null // DateConnection

--- a/examples/star-wars/src/schema.ts
+++ b/examples/star-wars/src/schema.ts
@@ -31,5 +31,5 @@ export const schema = makeSchema({
     ],
     contextType: 'swapi.ContextType',
   },
-  prettierConfig: require.resolve('../../../package.json'),
+  prettierConfig: require.resolve('../../../.prettierrc'),
 })

--- a/examples/ts-ast-reader/src/schema.ts
+++ b/examples/ts-ast-reader/src/schema.ts
@@ -29,7 +29,7 @@ export const schema = makeSchema({
     },
     // debug: true,
   },
-  prettierConfig: require.resolve('../../../package.json'),
+  prettierConfig: require.resolve('../../../.prettierrc'),
 })
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clean": "rm -rf dist*",
     "deploy-site": "yarn && yarn build",
     "dev": "tsc -p tsconfig.cjs.json -w",
-    "dev:examples": "yarn -s link-examples && tsc -w",
+    "dev:examples": "yarn -s link-examples && yarn dev",
     "dev:test": "jest --watch",
     "examples": "yarn link-examples && yarn gulp run-examples",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts' 'examples/*/src/**.ts'",

--- a/scripts/gulpfile.ts
+++ b/scripts/gulpfile.ts
@@ -34,11 +34,11 @@ gulp.task('link-examples', async () => {
 })
 
 gulp.task('api-tsc', () => {
-  runService('yarn', 'tsc -w -p api/tsconfig.json', { stdio: 'ignore' })
+  runService('yarn', 'tsc -w -p api/tsconfig.cjs.json', { stdio: 'ignore' })
 })
 
 gulp.task('core-tsc', () => {
-  runService('yarn', 'tsc -w -p tsconfig.json', {
+  runService('yarn', 'tsc -w -p tsconfig.cjs.json', {
     stdio: 'ignore',
     cwd: path.join(__dirname, '..'),
   })

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldResolver, GraphQLResolveInfo } from 'graphql'
 import { ArgsRecord, intArg, stringArg } from '../definitions/args'
-import { FieldOutConfig } from '../definitions/definitionBlocks'
+import { CommonFieldConfig, FieldOutConfig } from '../definitions/definitionBlocks'
 import { ObjectDefinitionBlock, objectType } from '../definitions/objectType'
 import { AllNexusOutputTypeDefs } from '../definitions/wrapping'
 import { dynamicOutputMethod } from '../dynamicMethod'
@@ -246,6 +246,7 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
       nodes?: never
     }
 ) &
+  Pick<CommonFieldConfig, 'deprecation' | 'description'> &
   NexusGenPluginFieldConfig<TypeName, FieldName>
 
 const ForwardPaginateArgs = {

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -246,7 +246,7 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
       nodes?: never
     }
 ) &
-  Pick<CommonFieldConfig, 'deprecation' | 'description'> &
+  Pick<CommonFieldConfig, 'deprecation' | 'description' | 'nullable'> &
   NexusGenPluginFieldConfig<TypeName, FieldName>
 
 const ForwardPaginateArgs = {


### PR DESCRIPTION
- Adds `description`, `deprecated`, and `nullable` as possible options for the `connectionField`
- Sets the correct path for prettier config when running the examples