### PR TITLE
improve: remove resolver shorthands

### DIFF
--- a/examples/apollo-fullstack/src/schema/launch.ts
+++ b/examples/apollo-fullstack/src/schema/launch.ts
@@ -1,31 +1,33 @@
-import { objectType } from "@nexus/schema";
-import dedent from "dedent";
+import dedent from 'dedent'
+import { objectType } from '@nexus/schema'
 
 export const Launch = objectType({
-  name: "Launch",
+  name: 'Launch',
   definition: (t) => {
-    t.id("id");
-    t.string("site", { nullable: true });
-    t.field("mission", { type: "Mission" });
-    t.field("rocket", { type: "Rocket" });
-    t.boolean("isBooked", (launch, _, { dataSources }) => {
-      return dataSources.userAPI.isBookedOnLaunch({
-        launchId: `${launch.id}`,
-      });
-    });
+    t.id('id')
+    t.string('site', { nullable: true })
+    t.field('mission', { type: 'Mission' })
+    t.field('rocket', { type: 'Rocket' })
+    t.boolean('isBooked', {
+      resolve: (launch, _, { dataSources }) => {
+        return dataSources.userAPI.isBookedOnLaunch({
+          launchId: `${launch.id}`,
+        })
+      },
+    })
   },
-});
+})
 
 export const LaunchConnection = objectType({
-  name: "LaunchConnection",
+  name: 'LaunchConnection',
   description: dedent`
     Simple wrapper around our list of launches that contains a cursor to the
     last item in the list. Pass this cursor to the launches query to fetch results
     after these.
   `,
   definition: (t) => {
-    t.string("cursor", { nullable: true });
-    t.boolean("hasMore");
-    t.field("launches", { type: "Launch", list: [false] });
+    t.string('cursor', { nullable: true })
+    t.boolean('hasMore')
+    t.field('launches', { type: 'Launch', list: [false] })
   },
-});
+})

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-nexus/example-kitchen-sink",
   "version": "0.0.0",
+  "license": "MIT",
   "scripts": {
     "build": "ts-node --log-error src/index.ts",
     "debug": "ts-node-dev --inspect-brk --no-notify --transpileOnly --respawn ./src",

--- a/examples/kitchen-sink/src/kitchen-sink-definitions.ts
+++ b/examples/kitchen-sink/src/kitchen-sink-definitions.ts
@@ -1,21 +1,21 @@
+import { connectionFromArray } from 'graphql-relay'
+import _ from 'lodash'
 import {
-  objectType,
-  inputObjectType,
-  interfaceType,
-  unionType,
   arg,
+  booleanArg,
+  connectionPlugin,
   extendType,
-  scalarType,
-  intArg,
   idArg,
+  inputObjectType,
+  intArg,
+  interfaceType,
   mutationField,
   mutationType,
-  booleanArg,
+  objectType,
   queryField,
-  connectionPlugin,
+  scalarType,
+  unionType,
 } from '@nexus/schema'
-import _ from 'lodash'
-import { connectionFromArray } from 'graphql-relay'
 
 const USERS_DATA = _.times(100, (i) => ({
   pk: i,
@@ -33,7 +33,7 @@ export const testArgs2 = {
 
 export const Mutation = mutationType({
   definition(t) {
-    t.boolean('ok', () => true)
+    t.boolean('ok', { resolve: () => true })
   },
 })
 
@@ -194,7 +194,7 @@ export const Query = objectType({
       },
       resolve: () => 'ok',
     })
-    t.list.date('dateAsList', () => [])
+    t.list.date('dateAsList', { resolve: () => [] })
 
     t.connectionField('booleanConnection', {
       type: 'Boolean',

--- a/examples/ts-ast-reader/package.json
+++ b/examples/ts-ast-reader/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-nexus/ts-ast-reader",
   "version": "0.0.0",
+  "license": "MIT",
   "scripts": {
     "start": "ts-node-dev --no-notify --transpileOnly --respawn ./src"
   },

--- a/examples/ts-ast-reader/src/types/interfaces.ts
+++ b/examples/ts-ast-reader/src/types/interfaces.ts
@@ -1,90 +1,90 @@
-import { interfaceType, arg } from "@nexus/schema";
-import { SyntaxKind, JSDoc } from "typescript";
-import { allKnownNodes, syntaxKindFilter } from "./utils";
+import { JSDoc, SyntaxKind } from 'typescript'
+import { arg, interfaceType } from '@nexus/schema'
+import { allKnownNodes, syntaxKindFilter } from './utils'
 
 const syntaxKindArgs = {
-  skip: arg({ type: "SyntaxKind", list: true }),
-  only: arg({ type: "SyntaxKind", list: true }),
-};
+  skip: arg({ type: 'SyntaxKind', list: true }),
+  only: arg({ type: 'SyntaxKind', list: true }),
+}
 
 export const MaybeOptional = interfaceType({
-  name: "MaybeOptional",
+  name: 'MaybeOptional',
   definition(t) {
-    t.field("questionToken", { type: "Token", nullable: true });
-    t.resolveType((o) => o.kind as any);
+    t.field('questionToken', { type: 'Token', nullable: true })
+    t.resolveType((o) => o.kind as any)
   },
-});
+})
 
 export const Node = interfaceType({
-  name: "Node",
+  name: 'Node',
   definition(t) {
-    t.int("pos");
-    t.int("end");
-    t.string("nameText", {
+    t.int('pos')
+    t.int('end')
+    t.string('nameText', {
       nullable: true,
       resolve: (root) =>
         // @ts-ignore
         root.name ? root.name.escapedText : null,
-    });
-    t.field("name", { type: "DeclarationName", nullable: true });
-    t.field("typeName", { type: "DeclarationName", nullable: true });
-    t.field("kind", { type: "SyntaxKind" });
-    t.int("kindCode", (o) => o.kind);
-    t.field("flags", { type: "NodeFlags" });
+    })
+    t.field('name', { type: 'DeclarationName', nullable: true })
+    t.field('typeName', { type: 'DeclarationName', nullable: true })
+    t.field('kind', { type: 'SyntaxKind' })
+    t.int('kindCode', { resolve: (o) => o.kind })
+    t.field('flags', { type: 'NodeFlags' })
     // t.field('decorators', 'Decorator', {list: true, nullable: true})
-    t.list.field("modifiers", {
-      type: "Token",
+    t.list.field('modifiers', {
+      type: 'Token',
       nullable: true,
       args: syntaxKindArgs,
       async resolve(root, args) {
         if (!root.modifiers) {
-          return null;
+          return null
         }
-        return syntaxKindFilter(args, Array.from(root.modifiers));
+        return syntaxKindFilter(args, Array.from(root.modifiers))
       },
-    });
-    t.field("parent", { type: "Node" });
-    t.string("rawText", {
+    })
+    t.field('parent', { type: 'Node' })
+    t.string('rawText', {
       args: syntaxKindArgs,
       resolve(root, args, ctx) {
-        const filtered = syntaxKindFilter(args, [root]);
-        return filtered.length ? filtered[0].getText(ctx.source) : "";
+        const filtered = syntaxKindFilter(args, [root])
+        return filtered.length ? filtered[0].getText(ctx.source) : ''
       },
-    });
+    })
     t.resolveType((node, ctx, info) => {
       if (KeywordKinds.has(node.kind)) {
-        return "KeywordTypeNode";
+        return 'KeywordTypeNode'
       }
       if (allKnownNodes(info.schema).has(SyntaxKind[node.kind])) {
-        return SyntaxKind[node.kind] as any;
+        return SyntaxKind[node.kind] as any
       }
-      return "UNKNOWN_NODE";
-    });
+      return 'UNKNOWN_NODE'
+    })
   },
-});
+})
 
 export const JSDocInterface = interfaceType({
-  name: "HasJSDoc",
+  name: 'HasJSDoc',
   definition(t) {
-    t.list.field("jsDoc", {
-      type: "JSDoc",
+    t.list.field('jsDoc', {
+      type: 'JSDoc',
       nullable: true,
       resolve(root) {
-        if ("jsDoc" in root) {
+        if ('jsDoc' in root) {
           // https://github.com/Microsoft/TypeScript/issues/19856
-          return ((root as unknown) as { jsDoc: JSDoc[] }).jsDoc;
+          return ((root as unknown) as { jsDoc: JSDoc[] }).jsDoc
         }
-        return null;
+        return null
       },
-    });
+    })
     t.resolveType((node, ctx, info) => {
       if (allKnownNodes(info.schema).has(SyntaxKind[node.kind])) {
-        return SyntaxKind[node.kind] as any;
+        return SyntaxKind[node.kind] as any
       }
-      return "UNKNOWN_NODE";
-    });
+      return 'UNKNOWN_NODE'
+    })
   },
-});
+})
 
 const KeywordKinds = new Set([
   SyntaxKind.AnyKeyword,
@@ -100,4 +100,4 @@ const KeywordKinds = new Set([
   SyntaxKind.UndefinedKeyword,
   SyntaxKind.NullKeyword,
   SyntaxKind.NeverKeyword,
-]);
+])

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -162,7 +162,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
       this.decorateField({
         name: fieldName,
         type: typeName,
-        ...opts[0],
+        ...(opts[0] as any),
       })
     )
   }

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -154,19 +154,21 @@ export class OutputDefinitionBlock<TypeName extends string> {
     typeName: BaseScalars,
     opts: [] | ScalarOutSpread<TypeName, any>
   ) {
-    if (typeof opts[0] === 'function') {
-      console.warn(
-        `Since v0.18.0 Nexus no longer supports resolver shorthands like:\n\n    t.string("${fieldName}", () => ...).\n\nInstead please write:\n\n    t.string("${fieldName}", { resolve: () => ... })`
-      )
+    let config: NexusOutputFieldDef = {
+      name: fieldName,
+      type: typeName,
     }
 
-    this.typeBuilder.addField(
-      this.decorateField({
-        name: fieldName,
-        type: typeName,
-        ...(opts[0] as any),
-      })
-    )
+    if (typeof opts[0] === 'function') {
+      config.resolve = opts[0] as any
+      console.warn(
+        `Since v0.18.0 Nexus no longer supports resolver shorthands like:\n\n    t.string("${fieldName}", () => ...).\n\nInstead please write:\n\n    t.string("${fieldName}", { resolve: () => ... })\n\nIn the next version of Nexus this will be a runtime error.`
+      )
+    } else {
+      config = { ...config, ...opts[0] }
+    }
+
+    this.typeBuilder.addField(this.decorateField(config))
   }
 
   protected decorateField(config: NexusOutputFieldDef): NexusOutputFieldDef {

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -58,13 +58,15 @@ export type NexusOutputFieldDef = NexusOutputFieldConfig<string, any> & {
 
 // prettier-ignore
 export type ScalarOutSpread<TypeName extends string, FieldName extends string> =
-  HasGen3<'argTypes', TypeName, FieldName> extends true
+  NeedsResolver<TypeName, FieldName> extends true
     ? [ScalarOutConfig<TypeName, FieldName>]
-    : [ScalarOutConfig<TypeName, FieldName>] | []
+    : HasGen3<'argTypes', TypeName, FieldName> extends true
+      ? [ScalarOutConfig<TypeName, FieldName>]
+      : [ScalarOutConfig<TypeName, FieldName>] | []
 
 // prettier-ignore
 export type ScalarOutConfig<TypeName extends string, FieldName extends string> =
-    NeedsResolver<TypeName, FieldName> extends true
+  NeedsResolver<TypeName, FieldName> extends true
     ? OutputScalarConfig<TypeName, FieldName> &
       {
         resolve: FieldResolver<TypeName, FieldName>

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -1,8 +1,8 @@
 import { GraphQLFieldResolver } from 'graphql'
 import { AllInputTypes, FieldResolver, GetGen, GetGen3, HasGen3, NeedsResolver } from '../typegenTypeHelpers'
+import { BaseScalars } from './_types'
 import { ArgsRecord } from './args'
 import { AllNexusInputTypeDefs, AllNexusOutputTypeDefs } from './wrapping'
-import { BaseScalars } from './_types'
 
 export interface CommonFieldConfig {
   /**
@@ -58,13 +58,9 @@ export type NexusOutputFieldDef = NexusOutputFieldConfig<string, any> & {
 
 // prettier-ignore
 export type ScalarOutSpread<TypeName extends string, FieldName extends string> =
-  NeedsResolver<TypeName, FieldName> extends true
-    ? HasGen3<'argTypes', TypeName, FieldName> extends true
-      ? [ScalarOutConfig<TypeName, FieldName>]
-      : [ScalarOutConfig<TypeName, FieldName>] | [FieldResolver<TypeName, FieldName>]
-    : HasGen3<'argTypes', TypeName, FieldName> extends true
-      ? [ScalarOutConfig<TypeName, FieldName>]
-      : [] | [FieldResolver<TypeName, FieldName>] | [ScalarOutConfig<TypeName, FieldName>]
+  HasGen3<'argTypes', TypeName, FieldName> extends true
+    ? [ScalarOutConfig<TypeName, FieldName>]
+    : [ScalarOutConfig<TypeName, FieldName>] | []
 
 // prettier-ignore
 export type ScalarOutConfig<TypeName extends string, FieldName extends string> =

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -64,12 +64,12 @@ export type ScalarOutSpread<TypeName extends string, FieldName extends string> =
 
 // prettier-ignore
 export type ScalarOutConfig<TypeName extends string, FieldName extends string> =
-    NeedsResolver<TypeName, FieldName> extends true
-    ? OutputScalarConfig<TypeName, FieldName> &
-      {
-        resolve: FieldResolver<TypeName, FieldName>
-      }
-    : OutputScalarConfig<TypeName, FieldName>
+  NeedsResolver<TypeName, FieldName> extends true
+    // todo static test for case where resolver needed
+    ? [ScalarOutConfig<TypeName, FieldName>]
+    : HasGen3<'argTypes', TypeName, FieldName> extends true
+      ? [ScalarOutConfig<TypeName, FieldName>]
+      : [] | [ScalarOutConfig<TypeName, FieldName>]
 
 export type FieldOutConfig<TypeName extends string, FieldName extends string> = NeedsResolver<
   TypeName,

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -152,17 +152,19 @@ export class OutputDefinitionBlock<TypeName extends string> {
     typeName: BaseScalars,
     opts: [] | ScalarOutSpread<TypeName, any>
   ) {
-    let config: NexusOutputFieldDef = {
-      name: fieldName,
-      type: typeName,
-    }
     if (typeof opts[0] === 'function') {
-      // FIXME ditto to the one in `field` method
-      config.resolve = opts[0] as any
-    } else {
-      config = { ...config, ...opts[0] }
+      console.warn(
+        `Since v0.18.0 Nexus no longer supports resolver shorthands like:\n\n    t.string("${fieldName}", () => ...).\n\nInstead please write:\n\n    t.string("${fieldName}", { resolve: () => ... })`
+      )
     }
-    this.typeBuilder.addField(this.decorateField(config))
+
+    this.typeBuilder.addField(
+      this.decorateField({
+        name: fieldName,
+        type: typeName,
+        ...opts[0],
+      })
+    )
   }
 
   protected decorateField(config: NexusOutputFieldDef): NexusOutputFieldDef {

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -64,12 +64,12 @@ export type ScalarOutSpread<TypeName extends string, FieldName extends string> =
 
 // prettier-ignore
 export type ScalarOutConfig<TypeName extends string, FieldName extends string> =
-  NeedsResolver<TypeName, FieldName> extends true
-    // todo static test for case where resolver needed
-    ? [ScalarOutConfig<TypeName, FieldName>]
-    : HasGen3<'argTypes', TypeName, FieldName> extends true
-      ? [ScalarOutConfig<TypeName, FieldName>]
-      : [] | [ScalarOutConfig<TypeName, FieldName>]
+    NeedsResolver<TypeName, FieldName> extends true
+    ? OutputScalarConfig<TypeName, FieldName> &
+      {
+        resolve: FieldResolver<TypeName, FieldName>
+      }
+    : OutputScalarConfig<TypeName, FieldName>
 
 export type FieldOutConfig<TypeName extends string, FieldName extends string> = NeedsResolver<
   TypeName,

--- a/tests/__helpers/helpers.ts
+++ b/tests/__helpers/helpers.ts
@@ -7,9 +7,9 @@ import { inputObjectType, objectType } from '../../src'
 export const UserObject = objectType({
   name: 'User',
   definition(t) {
-    t.id('id', () => `User:1` as any)
-    t.string('email', () => 'test@example.com' as any)
-    t.string('name', () => `Test User` as any)
+    t.id('id', { resolve: () => `User:1` as any })
+    t.string('email', { resolve: () => 'test@example.com' as any })
+    t.string('name', { resolve: () => `Test User` as any })
   },
 })
 

--- a/tests/backingTypes.spec.ts
+++ b/tests/backingTypes.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { core, enumType, makeSchema, objectType, queryType } from '..'
+import { core, enumType, makeSchema, objectType, queryType } from '../'
 import { A, B } from './_types'
 
 const { TypegenPrinter, TypegenMetadata } = core
@@ -121,7 +121,7 @@ describe('rootTypings', () => {
       name: 'SomeType',
       rootTyping: {
         name: 'invalid',
-        path: 'fzeffezpokm',
+        path: './fzeffezpokm',
       },
       definition(t) {
         t.id('id')
@@ -140,7 +140,7 @@ describe('rootTypings', () => {
     })
 
     expect(() => typegen.print()).toThrowErrorMatchingInlineSnapshot(
-      `"Expected an absolute path for the root typing path of the type SomeType, saw fzeffezpokm"`
+      `"Expected an absolute path for the root typing path of the type SomeType, saw ./fzeffezpokm"`
     )
   })
 
@@ -174,7 +174,7 @@ describe('rootTypings', () => {
       typegen.print()
     } catch (e) {
       expect(e.message.replace(__dirname, '')).toMatchInlineSnapshot(
-        `"Root typing path /invalid_path.ts of the type SomeType does not exist"`
+        `"Root typing path /invalid_path.ts for the type SomeType does not exist"`
       )
     }
   })

--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -16,7 +16,7 @@ import { mockStream } from '../../__helpers'
 
 export const query = queryType({
   definition(t) {
-    t.string('foo', () => 'bar')
+    t.string('foo', { resolve: () => 'bar' })
   },
 })
 

--- a/tests/plugins/connectionPlugin.spec.ts
+++ b/tests/plugins/connectionPlugin.spec.ts
@@ -640,7 +640,7 @@ describe('field level configuration', () => {
       {},
       {
         extendConnection(t) {
-          t.int('totalCount', () => 1)
+          t.int('totalCount', { resolve: () => 1 })
         },
       }
     )
@@ -653,7 +653,7 @@ describe('field level configuration', () => {
       {},
       {
         extendEdge(t) {
-          t.string('role', () => 'admin')
+          t.string('role', { resolve: () => 'admin' })
         },
       }
     )

--- a/tests/typegen/types.gen.ts
+++ b/tests/typegen/types.gen.ts
@@ -10,220 +10,206 @@ declare global {
 export interface NexusGenInputs {
   CreatePostInput: {
     // input type
-    author: string; // ID!
-    geo: Array<Array<number | null>>; // [[Float]!]!
-    name: string; // String!
-  };
+    author: string // ID!
+    geo: Array<Array<number | null>> // [[Float]!]!
+    name: string // String!
+  }
   PostFilters: {
     // input type
-    order: NexusGenEnums["OrderEnum"]; // OrderEnum!
-    search: string | null; // String
-  };
+    order: NexusGenEnums['OrderEnum'] // OrderEnum!
+    search: string | null // String
+  }
 }
 
 export interface NexusGenEnums {
-  OrderEnum: "ASC" | "DESC";
-  SomeEnum: "A" | "B";
+  OrderEnum: 'ASC' | 'DESC'
+  SomeEnum: 'A' | 'B'
 }
 
 export interface NexusGenScalars {
-  String: string;
-  Int: number;
-  Float: number;
-  Boolean: boolean;
-  ID: string;
-  UUID: any;
+  String: string
+  Int: number
+  Float: number
+  Boolean: boolean
+  ID: string
+  UUID: any
 }
 
 export interface NexusGenRootTypes {
-  Mutation: {};
-  Post: {};
-  Query: {};
-  User: {};
-  Node: NexusGenRootTypes["Post"] | NexusGenRootTypes["User"];
-  ExampleUnion: NexusGenRootTypes["Post"] | NexusGenRootTypes["User"];
+  Mutation: {}
+  Post: {}
+  Query: {}
+  User: {}
+  Node: NexusGenRootTypes['Post'] | NexusGenRootTypes['User']
+  ExampleUnion: NexusGenRootTypes['Post'] | NexusGenRootTypes['User']
 }
 
 export interface NexusGenAllTypes extends NexusGenRootTypes {
-  CreatePostInput: NexusGenInputs["CreatePostInput"];
-  PostFilters: NexusGenInputs["PostFilters"];
-  OrderEnum: NexusGenEnums["OrderEnum"];
-  SomeEnum: NexusGenEnums["SomeEnum"];
-  String: NexusGenScalars["String"];
-  Int: NexusGenScalars["Int"];
-  Float: NexusGenScalars["Float"];
-  Boolean: NexusGenScalars["Boolean"];
-  ID: NexusGenScalars["ID"];
-  UUID: NexusGenScalars["UUID"];
+  CreatePostInput: NexusGenInputs['CreatePostInput']
+  PostFilters: NexusGenInputs['PostFilters']
+  OrderEnum: NexusGenEnums['OrderEnum']
+  SomeEnum: NexusGenEnums['SomeEnum']
+  String: NexusGenScalars['String']
+  Int: NexusGenScalars['Int']
+  Float: NexusGenScalars['Float']
+  Boolean: NexusGenScalars['Boolean']
+  ID: NexusGenScalars['ID']
+  UUID: NexusGenScalars['UUID']
 }
 
 export interface NexusGenFieldTypes {
   Mutation: {
     // field return type
-    createPost: NexusGenRootTypes["Post"]; // Post!
-    registerClick: NexusGenRootTypes["Query"]; // Query!
-    someList: Array<string | null>; // [String]!
-  };
+    createPost: NexusGenRootTypes['Post'] // Post!
+    registerClick: NexusGenRootTypes['Query'] // Query!
+    someList: Array<string | null> // [String]!
+  }
   Post: {
     // field return type
-    author: NexusGenRootTypes["User"]; // User!
-    geo: number[][]; // [[Float!]!]!
-    id: string; // ID!
-    messyGeo: Array<number[] | null> | null; // [[Float!]]
-    uuid: NexusGenScalars["UUID"]; // UUID!
-  };
+    author: NexusGenRootTypes['User'] // User!
+    geo: number[][] // [[Float!]!]!
+    id: string // ID!
+    messyGeo: Array<number[] | null> | null // [[Float!]]
+    uuid: NexusGenScalars['UUID'] // UUID!
+  }
   Query: {
     // field return type
-    posts: NexusGenRootTypes["Post"][]; // [Post!]!
-    unionField: NexusGenRootTypes["ExampleUnion"]; // ExampleUnion!
-    user: NexusGenRootTypes["User"]; // User!
-  };
+    posts: NexusGenRootTypes['Post'][] // [Post!]!
+    unionField: NexusGenRootTypes['ExampleUnion'] // ExampleUnion!
+    user: NexusGenRootTypes['User'] // User!
+  }
   User: {
     // field return type
-    email: string; // String!
-    id: string; // ID!
-    name: string; // String!
-    outEnum: NexusGenEnums["SomeEnum"] | null; // SomeEnum
-    phone: string | null; // String
-    posts: NexusGenRootTypes["Post"][]; // [Post!]!
-  };
+    email: string // String!
+    id: string // ID!
+    name: string // String!
+    outEnum: NexusGenEnums['SomeEnum'] | null // SomeEnum
+    phone: string | null // String
+    posts: NexusGenRootTypes['Post'][] // [Post!]!
+  }
   Node: {
     // field return type
-    id: string; // ID!
-  };
+    id: string // ID!
+  }
 }
 
 export interface NexusGenFieldTypeNames {
   Mutation: {
     // field return type name
-    createPost: "Post";
-    registerClick: "Query";
-    someList: "String";
-  };
+    createPost: 'Post'
+    registerClick: 'Query'
+    someList: 'String'
+  }
   Post: {
     // field return type name
-    author: "User";
-    geo: "Float";
-    id: "ID";
-    messyGeo: "Float";
-    uuid: "UUID";
-  };
+    author: 'User'
+    geo: 'Float'
+    id: 'ID'
+    messyGeo: 'Float'
+    uuid: 'UUID'
+  }
   Query: {
     // field return type name
-    posts: "Post";
-    unionField: "ExampleUnion";
-    user: "User";
-  };
+    posts: 'Post'
+    unionField: 'ExampleUnion'
+    user: 'User'
+  }
   User: {
     // field return type name
-    email: "String";
-    id: "ID";
-    name: "String";
-    outEnum: "SomeEnum";
-    phone: "String";
-    posts: "Post";
-  };
+    email: 'String'
+    id: 'ID'
+    name: 'String'
+    outEnum: 'SomeEnum'
+    phone: 'String'
+    posts: 'Post'
+  }
   Node: {
     // field return type name
-    id: "ID";
-  };
+    id: 'ID'
+  }
 }
 
 export interface NexusGenArgTypes {
   Mutation: {
     createPost: {
       // args
-      input: NexusGenInputs["CreatePostInput"]; // CreatePostInput!
-    };
+      input: NexusGenInputs['CreatePostInput'] // CreatePostInput!
+    }
     registerClick: {
       // args
-      uuid?: NexusGenScalars["UUID"] | null; // UUID
-    };
+      uuid?: NexusGenScalars['UUID'] | null // UUID
+    }
     someList: {
       // args
-      items: Array<string | null>; // [String]!
-    };
-  };
+      items: Array<string | null> // [String]!
+    }
+  }
   Query: {
     posts: {
       // args
-      filters: NexusGenInputs["PostFilters"]; // PostFilters!
-    };
-  };
+      filters: NexusGenInputs['PostFilters'] // PostFilters!
+    }
+  }
   User: {
     name: {
       // args
-      prefix?: string | null; // String
-    };
+      prefix?: string | null // String
+    }
     posts: {
       // args
-      filters?: NexusGenInputs["PostFilters"] | null; // PostFilters
-    };
-  };
+      filters?: NexusGenInputs['PostFilters'] | null // PostFilters
+    }
+  }
 }
 
 export interface NexusGenAbstractResolveReturnTypes {
-  ExampleUnion: "Post" | "User";
-  Node: "Post" | "User";
+  ExampleUnion: 'Post' | 'User'
+  Node: 'Post' | 'User'
 }
 
 export interface NexusGenInheritedFields {}
 
-export type NexusGenObjectNames = "Mutation" | "Post" | "Query" | "User";
+export type NexusGenObjectNames = 'Mutation' | 'Post' | 'Query' | 'User'
 
-export type NexusGenInputNames = "CreatePostInput" | "PostFilters";
+export type NexusGenInputNames = 'CreatePostInput' | 'PostFilters'
 
-export type NexusGenEnumNames = "OrderEnum" | "SomeEnum";
+export type NexusGenEnumNames = 'OrderEnum' | 'SomeEnum'
 
-export type NexusGenInterfaceNames = "Node";
+export type NexusGenInterfaceNames = 'Node'
 
-export type NexusGenScalarNames =
-  | "Boolean"
-  | "Float"
-  | "ID"
-  | "Int"
-  | "String"
-  | "UUID";
+export type NexusGenScalarNames = 'Boolean' | 'Float' | 'ID' | 'Int' | 'String' | 'UUID'
 
-export type NexusGenUnionNames = "ExampleUnion";
+export type NexusGenUnionNames = 'ExampleUnion'
 
 export interface NexusGenTypes {
-  context: any;
-  inputTypes: NexusGenInputs;
-  rootTypes: NexusGenRootTypes;
-  argTypes: NexusGenArgTypes;
-  fieldTypes: NexusGenFieldTypes;
-  fieldTypeNames: NexusGenFieldTypeNames;
-  allTypes: NexusGenAllTypes;
-  inheritedFields: NexusGenInheritedFields;
-  objectNames: NexusGenObjectNames;
-  inputNames: NexusGenInputNames;
-  enumNames: NexusGenEnumNames;
-  interfaceNames: NexusGenInterfaceNames;
-  scalarNames: NexusGenScalarNames;
-  unionNames: NexusGenUnionNames;
-  allInputTypes:
-    | NexusGenTypes["inputNames"]
-    | NexusGenTypes["enumNames"]
-    | NexusGenTypes["scalarNames"];
+  context: any
+  inputTypes: NexusGenInputs
+  rootTypes: NexusGenRootTypes
+  argTypes: NexusGenArgTypes
+  fieldTypes: NexusGenFieldTypes
+  fieldTypeNames: NexusGenFieldTypeNames
+  allTypes: NexusGenAllTypes
+  inheritedFields: NexusGenInheritedFields
+  objectNames: NexusGenObjectNames
+  inputNames: NexusGenInputNames
+  enumNames: NexusGenEnumNames
+  interfaceNames: NexusGenInterfaceNames
+  scalarNames: NexusGenScalarNames
+  unionNames: NexusGenUnionNames
+  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames']
   allOutputTypes:
-    | NexusGenTypes["objectNames"]
-    | NexusGenTypes["enumNames"]
-    | NexusGenTypes["unionNames"]
-    | NexusGenTypes["interfaceNames"]
-    | NexusGenTypes["scalarNames"];
-  allNamedTypes:
-    | NexusGenTypes["allInputTypes"]
-    | NexusGenTypes["allOutputTypes"];
-  abstractTypes: NexusGenTypes["interfaceNames"] | NexusGenTypes["unionNames"];
-  abstractResolveReturn: NexusGenAbstractResolveReturnTypes;
+    | NexusGenTypes['objectNames']
+    | NexusGenTypes['enumNames']
+    | NexusGenTypes['unionNames']
+    | NexusGenTypes['interfaceNames']
+    | NexusGenTypes['scalarNames']
+  allNamedTypes: NexusGenTypes['allInputTypes'] | NexusGenTypes['allOutputTypes']
+  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames']
+  abstractResolveReturn: NexusGenAbstractResolveReturnTypes
 }
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
-  interface NexusGenPluginFieldConfig<
-    TypeName extends string,
-    FieldName extends string
-  > {}
+  interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}
 }

--- a/tests/typegen/types.gen.ts
+++ b/tests/typegen/types.gen.ts
@@ -10,206 +10,220 @@ declare global {
 export interface NexusGenInputs {
   CreatePostInput: {
     // input type
-    author: string // ID!
-    geo: Array<Array<number | null>> // [[Float]!]!
-    name: string // String!
-  }
+    author: string; // ID!
+    geo: Array<Array<number | null>>; // [[Float]!]!
+    name: string; // String!
+  };
   PostFilters: {
     // input type
-    order: NexusGenEnums['OrderEnum'] // OrderEnum!
-    search: string | null // String
-  }
+    order: NexusGenEnums["OrderEnum"]; // OrderEnum!
+    search: string | null; // String
+  };
 }
 
 export interface NexusGenEnums {
-  OrderEnum: 'ASC' | 'DESC'
-  SomeEnum: 'A' | 'B'
+  OrderEnum: "ASC" | "DESC";
+  SomeEnum: "A" | "B";
 }
 
 export interface NexusGenScalars {
-  String: string
-  Int: number
-  Float: number
-  Boolean: boolean
-  ID: string
-  UUID: any
+  String: string;
+  Int: number;
+  Float: number;
+  Boolean: boolean;
+  ID: string;
+  UUID: any;
 }
 
 export interface NexusGenRootTypes {
-  Mutation: {}
-  Post: {}
-  Query: {}
-  User: {}
-  Node: NexusGenRootTypes['Post'] | NexusGenRootTypes['User']
-  ExampleUnion: NexusGenRootTypes['Post'] | NexusGenRootTypes['User']
+  Mutation: {};
+  Post: {};
+  Query: {};
+  User: {};
+  Node: NexusGenRootTypes["Post"] | NexusGenRootTypes["User"];
+  ExampleUnion: NexusGenRootTypes["Post"] | NexusGenRootTypes["User"];
 }
 
 export interface NexusGenAllTypes extends NexusGenRootTypes {
-  CreatePostInput: NexusGenInputs['CreatePostInput']
-  PostFilters: NexusGenInputs['PostFilters']
-  OrderEnum: NexusGenEnums['OrderEnum']
-  SomeEnum: NexusGenEnums['SomeEnum']
-  String: NexusGenScalars['String']
-  Int: NexusGenScalars['Int']
-  Float: NexusGenScalars['Float']
-  Boolean: NexusGenScalars['Boolean']
-  ID: NexusGenScalars['ID']
-  UUID: NexusGenScalars['UUID']
+  CreatePostInput: NexusGenInputs["CreatePostInput"];
+  PostFilters: NexusGenInputs["PostFilters"];
+  OrderEnum: NexusGenEnums["OrderEnum"];
+  SomeEnum: NexusGenEnums["SomeEnum"];
+  String: NexusGenScalars["String"];
+  Int: NexusGenScalars["Int"];
+  Float: NexusGenScalars["Float"];
+  Boolean: NexusGenScalars["Boolean"];
+  ID: NexusGenScalars["ID"];
+  UUID: NexusGenScalars["UUID"];
 }
 
 export interface NexusGenFieldTypes {
   Mutation: {
     // field return type
-    createPost: NexusGenRootTypes['Post'] // Post!
-    registerClick: NexusGenRootTypes['Query'] // Query!
-    someList: Array<string | null> // [String]!
-  }
+    createPost: NexusGenRootTypes["Post"]; // Post!
+    registerClick: NexusGenRootTypes["Query"]; // Query!
+    someList: Array<string | null>; // [String]!
+  };
   Post: {
     // field return type
-    author: NexusGenRootTypes['User'] // User!
-    geo: number[][] // [[Float!]!]!
-    id: string // ID!
-    messyGeo: Array<number[] | null> | null // [[Float!]]
-    uuid: NexusGenScalars['UUID'] // UUID!
-  }
+    author: NexusGenRootTypes["User"]; // User!
+    geo: number[][]; // [[Float!]!]!
+    id: string; // ID!
+    messyGeo: Array<number[] | null> | null; // [[Float!]]
+    uuid: NexusGenScalars["UUID"]; // UUID!
+  };
   Query: {
     // field return type
-    posts: NexusGenRootTypes['Post'][] // [Post!]!
-    unionField: NexusGenRootTypes['ExampleUnion'] // ExampleUnion!
-    user: NexusGenRootTypes['User'] // User!
-  }
+    posts: NexusGenRootTypes["Post"][]; // [Post!]!
+    unionField: NexusGenRootTypes["ExampleUnion"]; // ExampleUnion!
+    user: NexusGenRootTypes["User"]; // User!
+  };
   User: {
     // field return type
-    email: string // String!
-    id: string // ID!
-    name: string // String!
-    outEnum: NexusGenEnums['SomeEnum'] | null // SomeEnum
-    phone: string | null // String
-    posts: NexusGenRootTypes['Post'][] // [Post!]!
-  }
+    email: string; // String!
+    id: string; // ID!
+    name: string; // String!
+    outEnum: NexusGenEnums["SomeEnum"] | null; // SomeEnum
+    phone: string | null; // String
+    posts: NexusGenRootTypes["Post"][]; // [Post!]!
+  };
   Node: {
     // field return type
-    id: string // ID!
-  }
+    id: string; // ID!
+  };
 }
 
 export interface NexusGenFieldTypeNames {
   Mutation: {
     // field return type name
-    createPost: 'Post'
-    registerClick: 'Query'
-    someList: 'String'
-  }
+    createPost: "Post";
+    registerClick: "Query";
+    someList: "String";
+  };
   Post: {
     // field return type name
-    author: 'User'
-    geo: 'Float'
-    id: 'ID'
-    messyGeo: 'Float'
-    uuid: 'UUID'
-  }
+    author: "User";
+    geo: "Float";
+    id: "ID";
+    messyGeo: "Float";
+    uuid: "UUID";
+  };
   Query: {
     // field return type name
-    posts: 'Post'
-    unionField: 'ExampleUnion'
-    user: 'User'
-  }
+    posts: "Post";
+    unionField: "ExampleUnion";
+    user: "User";
+  };
   User: {
     // field return type name
-    email: 'String'
-    id: 'ID'
-    name: 'String'
-    outEnum: 'SomeEnum'
-    phone: 'String'
-    posts: 'Post'
-  }
+    email: "String";
+    id: "ID";
+    name: "String";
+    outEnum: "SomeEnum";
+    phone: "String";
+    posts: "Post";
+  };
   Node: {
     // field return type name
-    id: 'ID'
-  }
+    id: "ID";
+  };
 }
 
 export interface NexusGenArgTypes {
   Mutation: {
     createPost: {
       // args
-      input: NexusGenInputs['CreatePostInput'] // CreatePostInput!
-    }
+      input: NexusGenInputs["CreatePostInput"]; // CreatePostInput!
+    };
     registerClick: {
       // args
-      uuid?: NexusGenScalars['UUID'] | null // UUID
-    }
+      uuid?: NexusGenScalars["UUID"] | null; // UUID
+    };
     someList: {
       // args
-      items: Array<string | null> // [String]!
-    }
-  }
+      items: Array<string | null>; // [String]!
+    };
+  };
   Query: {
     posts: {
       // args
-      filters: NexusGenInputs['PostFilters'] // PostFilters!
-    }
-  }
+      filters: NexusGenInputs["PostFilters"]; // PostFilters!
+    };
+  };
   User: {
     name: {
       // args
-      prefix?: string | null // String
-    }
+      prefix?: string | null; // String
+    };
     posts: {
       // args
-      filters?: NexusGenInputs['PostFilters'] | null // PostFilters
-    }
-  }
+      filters?: NexusGenInputs["PostFilters"] | null; // PostFilters
+    };
+  };
 }
 
 export interface NexusGenAbstractResolveReturnTypes {
-  ExampleUnion: 'Post' | 'User'
-  Node: 'Post' | 'User'
+  ExampleUnion: "Post" | "User";
+  Node: "Post" | "User";
 }
 
 export interface NexusGenInheritedFields {}
 
-export type NexusGenObjectNames = 'Mutation' | 'Post' | 'Query' | 'User'
+export type NexusGenObjectNames = "Mutation" | "Post" | "Query" | "User";
 
-export type NexusGenInputNames = 'CreatePostInput' | 'PostFilters'
+export type NexusGenInputNames = "CreatePostInput" | "PostFilters";
 
-export type NexusGenEnumNames = 'OrderEnum' | 'SomeEnum'
+export type NexusGenEnumNames = "OrderEnum" | "SomeEnum";
 
-export type NexusGenInterfaceNames = 'Node'
+export type NexusGenInterfaceNames = "Node";
 
-export type NexusGenScalarNames = 'Boolean' | 'Float' | 'ID' | 'Int' | 'String' | 'UUID'
+export type NexusGenScalarNames =
+  | "Boolean"
+  | "Float"
+  | "ID"
+  | "Int"
+  | "String"
+  | "UUID";
 
-export type NexusGenUnionNames = 'ExampleUnion'
+export type NexusGenUnionNames = "ExampleUnion";
 
 export interface NexusGenTypes {
-  context: any
-  inputTypes: NexusGenInputs
-  rootTypes: NexusGenRootTypes
-  argTypes: NexusGenArgTypes
-  fieldTypes: NexusGenFieldTypes
-  fieldTypeNames: NexusGenFieldTypeNames
-  allTypes: NexusGenAllTypes
-  inheritedFields: NexusGenInheritedFields
-  objectNames: NexusGenObjectNames
-  inputNames: NexusGenInputNames
-  enumNames: NexusGenEnumNames
-  interfaceNames: NexusGenInterfaceNames
-  scalarNames: NexusGenScalarNames
-  unionNames: NexusGenUnionNames
-  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames']
+  context: any;
+  inputTypes: NexusGenInputs;
+  rootTypes: NexusGenRootTypes;
+  argTypes: NexusGenArgTypes;
+  fieldTypes: NexusGenFieldTypes;
+  fieldTypeNames: NexusGenFieldTypeNames;
+  allTypes: NexusGenAllTypes;
+  inheritedFields: NexusGenInheritedFields;
+  objectNames: NexusGenObjectNames;
+  inputNames: NexusGenInputNames;
+  enumNames: NexusGenEnumNames;
+  interfaceNames: NexusGenInterfaceNames;
+  scalarNames: NexusGenScalarNames;
+  unionNames: NexusGenUnionNames;
+  allInputTypes:
+    | NexusGenTypes["inputNames"]
+    | NexusGenTypes["enumNames"]
+    | NexusGenTypes["scalarNames"];
   allOutputTypes:
-    | NexusGenTypes['objectNames']
-    | NexusGenTypes['enumNames']
-    | NexusGenTypes['unionNames']
-    | NexusGenTypes['interfaceNames']
-    | NexusGenTypes['scalarNames']
-  allNamedTypes: NexusGenTypes['allInputTypes'] | NexusGenTypes['allOutputTypes']
-  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames']
-  abstractResolveReturn: NexusGenAbstractResolveReturnTypes
+    | NexusGenTypes["objectNames"]
+    | NexusGenTypes["enumNames"]
+    | NexusGenTypes["unionNames"]
+    | NexusGenTypes["interfaceNames"]
+    | NexusGenTypes["scalarNames"];
+  allNamedTypes:
+    | NexusGenTypes["allInputTypes"]
+    | NexusGenTypes["allOutputTypes"];
+  abstractTypes: NexusGenTypes["interfaceNames"] | NexusGenTypes["unionNames"];
+  abstractResolveReturn: NexusGenAbstractResolveReturnTypes;
 }
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
-  interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginFieldConfig<
+    TypeName extends string,
+    FieldName extends string
+  > {}
   interface NexusGenPluginSchemaConfig {}
 }

--- a/tests/unionType.spec.ts
+++ b/tests/unionType.spec.ts
@@ -9,7 +9,7 @@ describe('unionType', () => {
         objectType({
           name: 'DeletedUser',
           definition(t) {
-            t.string('message', (root) => `This user ${root.id} was deleted`)
+            t.string('message', { resolve: (root) => `This user ${root.id} was deleted` })
           },
           rootTyping: `{ id: number; deletedAt: Date }`,
         }),


### PR DESCRIPTION
closes #582

As discussed. In most cases resolver shorthands are not a serious use of the API.

BREAKING CHANGE:

Resolver shorthand API is now removed. The following will now not typecheck:

```ts
t.string('foo', () => ... )
```

Instead use:

```ts
t.string('foo', { resolve: () => ... })
```

Runtime support is still intact but will result in a logged warning. Runtime support will be removed in the next Nexus release.

--- 

I probably missed areas of the codebase that can be simplified as a result. In particular the parts in the builder module that need to do runtime checks. Also maybe something about typegen?