### PR TITLE
fix: #588, #384 non-null list items & connection nullability

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1217,15 +1217,22 @@ export class SchemaBuilder {
     isNonNull: boolean
   ): T {
     if (list) {
-      type = this.decorateList(type, list)
+      type = this.decorateList(type, list, isNonNull)
     }
     return (isNonNull ? GraphQLNonNull(type) : type) as T
   }
 
-  protected decorateList<T extends GraphQLOutputType | GraphQLInputType>(type: T, list: true | boolean[]): T {
+  protected decorateList<T extends GraphQLOutputType | GraphQLInputType>(
+    type: T,
+    list: true | boolean[],
+    isNonNull: boolean
+  ): T {
     let finalType = type
     if (!Array.isArray(list)) {
-      return GraphQLList(type) as T
+      if (isNonNull) {
+        finalType = GraphQLNonNull(finalType) as T
+      }
+      return GraphQLList(finalType) as T
     }
     if (Array.isArray(list)) {
       for (let i = 0; i < list.length; i++) {

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -23,6 +23,7 @@ import {
   pathToArray,
   printedGenTypingImport,
 } from '../utils'
+import { NonNullConfig } from '../definitions/_types'
 
 export interface ConnectionPluginConfig {
   /**
@@ -126,6 +127,11 @@ export interface ConnectionPluginConfig {
    * direct dependency at the application level.
    */
   nexusSchemaImportId?: string
+  /**
+   * Configures the default "nonNullDefaults" settings for any connection types
+   * created globally by this config / connection field.
+   */
+  nonNullDefaults?: NonNullConfig
 }
 
 // Extract the node value from the connection for a given field.
@@ -201,6 +207,11 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
    * so as not to conflict with any non-extended connections.
    */
   extendEdge?: (def: ObjectDefinitionBlock<any>) => void
+  /**
+   * Configures the default "nonNullDefaults" for connection type generated
+   * for this connection
+   */
+  nonNullDefaults?: NonNullConfig
 } & (
   | {
       /**
@@ -401,11 +412,9 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                 objectType({
                   name: connectionName as any,
                   definition(t2) {
-                    t2.field('edges', {
+                    t2.list.field('edges', {
                       type: edgeName as any,
                       description: `https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types`,
-                      nullable: true,
-                      list: [false],
                     })
                     t2.field('pageInfo', {
                       type: 'PageInfo' as any,
@@ -430,6 +439,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                       fieldConfig.extendConnection(t2)
                     }
                   },
+                  nonNullDefaults: fieldConfig.nonNullDefaults ?? pluginConfig.nonNullDefaults,
                 })
               )
             }
@@ -460,6 +470,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                       fieldConfig.extendEdge(t2)
                     }
                   },
+                  nonNullDefaults: fieldConfig.nonNullDefaults ?? pluginConfig.nonNullDefaults,
                 })
               )
             }

--- a/tests/__snapshots__/nonNullDefaults.spec.ts.snap
+++ b/tests/__snapshots__/nonNullDefaults.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`nonNullDefaults false/false on schema 1`] = `
 "type Query {
   test(test: Int): Boolean
+  stringList: [String]
 }
 "
 `;
@@ -10,6 +11,7 @@ exports[`nonNullDefaults false/false on schema 1`] = `
 exports[`nonNullDefaults false/false on type 1`] = `
 "type Query {
   test(test: Int): Boolean
+  stringList: [String]
 }
 "
 `;
@@ -17,6 +19,7 @@ exports[`nonNullDefaults false/false on type 1`] = `
 exports[`nonNullDefaults true/true on schema 1`] = `
 "type Query {
   test(test: Int!): Boolean!
+  stringList: [String!]!
 }
 "
 `;
@@ -24,6 +27,7 @@ exports[`nonNullDefaults true/true on schema 1`] = `
 exports[`nonNullDefaults true/true on type 1`] = `
 "type Query {
   test(test: Int!): Boolean!
+  stringList: [String!]!
 }
 "
 `;

--- a/tests/nonNullDefaults.spec.ts
+++ b/tests/nonNullDefaults.spec.ts
@@ -49,6 +49,9 @@ function makeQuery(config?: Partial<core.NexusObjectTypeConfig<string>>) {
           test: intArg(),
         },
       })
+      t.list.field('stringList', {
+        type: 'String',
+      })
     },
   })
 }

--- a/tests/typegenPrinter.spec.ts
+++ b/tests/typegenPrinter.spec.ts
@@ -15,7 +15,7 @@ describe('typegenPrinter', () => {
       },
       shouldGenerateArtifacts: true,
       types: [buildSchema(EXAMPLE_SDL)],
-      prettierConfig: path.join(__dirname, '../package.json'),
+      prettierConfig: path.join(__dirname, '../.prettierrc'),
     }) as core.NexusGraphQLSchema
     metadata = new TypegenMetadata({
       outputs: {


### PR DESCRIPTION
Fixes #588 by ensuring that list items follow `nonNullDefaults`, which was lost in the #508 refactor

Fixes #384 by removing explicit nullability config from the connection `edges` definition, and also allowing `nonNullDefaults` to be supplied for the connection "types" generated by the creation of a connection field. Allows you to configure both globally in the connection plugin field config, and when the connection field is defined.