### PR TITLE
feat: interfaces implementing interfaces can resolveType w/ interface name

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -39,6 +39,7 @@ import {
   isUnionType,
   isWrappingType,
   printSchema,
+  defaultTypeResolver,
 } from 'graphql'
 import { arg, ArgsRecord, NexusArgConfig, NexusArgDef } from './definitions/args'
 import {
@@ -925,8 +926,9 @@ export class SchemaBuilder {
       const typeName = resolveType(source, ctx, info, absType)
       if (typeof typeName === 'string') {
         const type = info.schema.getType(typeName)
-        if (isInterfaceType(type) && type.resolveType) {
-          return type.resolveType(source, ctx, info, absType)
+        if (isInterfaceType(type)) {
+          let interfaceResolveType = type.resolveType ?? defaultTypeResolver
+          return interfaceResolveType(source, ctx, info, absType)
         }
         return typeName
       }

--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -1,4 +1,4 @@
-import { GraphQLResolveInfo } from 'graphql'
+import { GraphQLResolveInfo, GraphQLAbstractType } from 'graphql'
 
 declare global {
   interface NexusGen {}
@@ -75,7 +75,8 @@ export interface AbstractTypeResolver<TypeName extends string> {
   (
     source: RootValue<TypeName>,
     context: GetGen<'context'>,
-    info: GraphQLResolveInfo
+    info: GraphQLResolveInfo,
+    abstractType: GraphQLAbstractType
   ): MaybePromise<AbstractResolveReturn<TypeName> | null>
 }
 

--- a/tests/__snapshots__/interfaceType.spec.ts.snap
+++ b/tests/__snapshots__/interfaceType.spec.ts.snap
@@ -26,6 +26,19 @@ Object {
 
 exports[`interfaceType can not implement itself 1`] = `"GraphQL Nexus: Interface Node can't implement itself"`;
 
+exports[`interfaceType can resolve interfaces 1`] = `
+Object {
+  "data": Object {
+    "organism": Object {
+      "breed": "Puli",
+      "classification": "Canis familiaris",
+      "owner": "Mark",
+      "type": "Animal",
+    },
+  },
+}
+`;
+
 exports[`interfaceType detects circular dependencies 1`] = `"GraphQL Nexus: Interface circular dependency detected NodeA -> NodeC -> NodeB -> NodeA"`;
 
 exports[`interfaceType logs error when resolveType is not provided for an interface 1`] = `


### PR DESCRIPTION
Will probably also try to upstream this PR's behavior to `graphql-js`, but it seems to make sense that if you have an `interface` which implements another `interface`, in the `resolveType` of the parent you should be able to `resolveType` an implementing interface's `__typename`, and it'd then cascade into that interface type's `resolveType` to determine the concrete type.