### PR TITLE
chore: Refine exports for plugins

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,6 +1,11 @@
 export { connectionPlugin } from './connectionPlugin'
-export * from './fieldAuthorizePlugin'
-export * from './nullabilityGuardPlugin'
-export * from './queryComplexityPlugin'
-export { connectionPluginCore }
-import * as connectionPluginCore from './connectionPlugin'
+export * as connectionPluginCore from './connectionPlugin'
+
+export { fieldAuthorizePlugin } from './fieldAuthorizePlugin'
+export * as fieldAuthorizePluginCore from './fieldAuthorizePlugin'
+
+export { nullabilityGuardPlugin } from './nullabilityGuardPlugin'
+export * as nullabilityGuardPluginCore from './nullabilityGuardPlugin'
+
+export { queryComplexityPlugin } from './queryComplexityPlugin'
+export * as queryComplexityPluginCore from './queryComplexityPlugin'

--- a/tests/plugin.spec.ts
+++ b/tests/plugin.spec.ts
@@ -38,7 +38,6 @@ describe('plugin', () => {
           onBeforeBuild: () => lifecycleCalls.push('onBeforeBuild'),
           onInstall: () => {
             lifecycleCalls.push('onInstall')
-            return { types: [] }
           },
           onCreateFieldResolver({ fieldConfig }) {
             return async (root, args, ctx, info, next) => {


### PR DESCRIPTION
Noticed a bunch of things were showing up on the top-level API because of `export *` for various plugins.

We want to group these things under namespaces and keep the top level API clean when we can.