### PR TITLE
feat(config): SDL file generation by default in development

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -178,13 +178,20 @@ export interface BuilderConfigInput {
          */
         typegen?: boolean | string
         /**
-         * GraphQL SDL generation settings. This file is not necessary but
+         * GraphQL SDL file generation toggle and location.
+         *
+         * Set to a string to enable and output to an absolute path.
+         * Set to true to enable at default path (schema.graphql in the current working directory)
+         * Set to false to disable
+         *
+         * Defaults to true in development and false otherwise.
+         *
+         * @remarks
+         *
+         * This file is not necessary but
          * may be nice for teams wishing to review SDL in pull-requests or
          * just generally transitioning from a schema-first workflow.
          *
-         * Defaults to false (disabled). Set to true to enable and emit into
-         * default path (current working directory). Set to a string to specify
-         * absolute path.
          */
         schema?: boolean | string
       }
@@ -1702,7 +1709,9 @@ export function setConfigDefaults(config: BuilderConfigInput): BuilderConfig {
 export function makeSchema(config: SchemaConfig): NexusGraphQLSchema {
   const { schema, missingTypes, finalConfig } = makeSchemaInternal(config)
   const typegenConfig = resolveTypegenConfig(finalConfig)
-  if (typegenConfig.outputs.schema || typegenConfig.outputs.typegen) {
+  const sdl = typegenConfig.outputs.schema
+  const typegen = typegenConfig.outputs.typegen
+  if (sdl || typegen) {
     // Generating in the next tick allows us to use the schema
     // in the optional thunk for the typegen config
     const typegenPromise = new TypegenMetadata(typegenConfig).generateArtifacts(schema)

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1757,7 +1757,7 @@ export async function generateSchema(config: SchemaConfig): Promise<NexusGraphQL
  */
 generateSchema.withArtifacts = async (
   config: SchemaConfig,
-  typeFilePath: string | false = false
+  typeFilePath: string | null = null
 ): Promise<{
   schema: NexusGraphQLSchema
   schemaTypes: string

--- a/src/typegenMetadata.ts
+++ b/src/typegenMetadata.ts
@@ -11,8 +11,8 @@ export interface TypegenMetadataConfig
   extends Omit<BuilderConfigInput, 'outputs' | 'shouldGenerateArtifacts'> {
   nexusSchemaImportId?: string
   outputs: {
-    schema: false | string
-    typegen: false | string
+    schema: null | string
+    typegen: null | string
   }
 }
 
@@ -44,7 +44,7 @@ export class TypegenMetadata {
     }
   }
 
-  async generateArtifactContents(schema: NexusGraphQLSchema, typeFilePath: string | false) {
+  async generateArtifactContents(schema: NexusGraphQLSchema, typeFilePath: string | null) {
     const [schemaTypes, tsTypes] = await Promise.all([
       this.generateSchemaFile(schema),
       typeFilePath ? this.generateTypesFile(schema, typeFilePath) : '',

--- a/src/typegenUtils.ts
+++ b/src/typegenUtils.ts
@@ -1,4 +1,4 @@
-import * as Path from 'path'
+import * as path from 'path'
 import { BuilderConfigInput } from './builder'
 import { TypegenMetadataConfig } from './typegenMetadata'
 import { assertAbsolutePath, getOwnPackage, isProductionStage } from './utils'
@@ -13,7 +13,7 @@ export function resolveTypegenConfig(config: BuilderConfigInput): TypegenMetadat
     ...rest
   } = config
 
-  const defaultSDLFilePath = Path.join(process.cwd(), 'schema.graphql')
+  const defaultSDLFilePath = path.join(process.cwd(), 'schema.graphql')
 
   let typegenFilePath: string | null = null
   let sdlFilePath: string | null = null

--- a/tests/backingTypes.spec.ts
+++ b/tests/backingTypes.spec.ts
@@ -90,7 +90,7 @@ describe('backingTypes', () => {
 describe('rootTypings', () => {
   it('can import enum via rootTyping', async () => {
     const metadata = new TypegenMetadata({
-      outputs: { typegen: false, schema: false },
+      outputs: { typegen: null, schema: null },
     })
     const schema = makeSchema({
       types: [
@@ -115,7 +115,7 @@ describe('rootTypings', () => {
 
   it('throws error if root typing path is not an absolute path', async () => {
     const metadata = new TypegenMetadata({
-      outputs: { typegen: false, schema: false },
+      outputs: { typegen: null, schema: null },
     })
     const someType = objectType({
       name: 'SomeType',
@@ -146,7 +146,7 @@ describe('rootTypings', () => {
 
   it('throws error if root typing path does not exist', async () => {
     const metadata = new TypegenMetadata({
-      outputs: { typegen: false, schema: false },
+      outputs: { typegen: null, schema: null },
     })
     const someType = objectType({
       name: 'SomeType',

--- a/tests/interfaceType.spec.ts
+++ b/tests/interfaceType.spec.ts
@@ -164,7 +164,7 @@ describe('interfaceType', () => {
         ],
         outputs: false,
       },
-      false
+      null
     )
     expect(schemaTypes).toMatchSnapshot()
   })

--- a/tests/makeSchema.spec.ts
+++ b/tests/makeSchema.spec.ts
@@ -76,7 +76,7 @@ describe('makeSchema', () => {
             return printSchema(schema, { commentDescriptions: true })
           },
         },
-        false
+        null
       )
       expect(schemaTypes).toMatchSnapshot()
     })


### PR DESCRIPTION
closes #632

BREAKING CHANGE:

SDL file generation will be enabled by default in development now.

If you were enabling it manually before and outputting to project root at `schema.graphql` You can probably now just rely on the default.

If you were relying on the default to disable SDL file generation before then now you need to pass an explicit false:

```ts
makeSchema({
  outputs: {
    schema: false
  }
})
```