### PR TITLE
fix: Fix #622, custom scalars should work with interfaceType

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -809,7 +809,7 @@ export class SchemaBuilder {
           }),
         addModification: () => {},
         addField: () => {},
-        addDynamicOutputMembers: () => {},
+        addDynamicOutputMembers: (block, wrapping) => this.addDynamicOutputMembers(block, 'walk', wrapping),
         warn: () => {},
       })
       obj.definition(definitionBlock)

--- a/tests/interfaceType.spec.ts
+++ b/tests/interfaceType.spec.ts
@@ -1,6 +1,7 @@
 import { graphql } from 'graphql'
 import path from 'path'
-import { generateSchema, interfaceType, makeSchema, objectType, queryField } from '../src/core'
+import { DateTimeResolver } from 'graphql-scalars'
+import { generateSchema, interfaceType, makeSchema, objectType, queryField, asNexusMethod } from '../src/core'
 
 describe('interfaceType', () => {
   it('can be implemented by object types', async () => {
@@ -10,8 +11,11 @@ describe('interfaceType', () => {
           name: 'Node',
           definition(t) {
             t.id('id')
+            // @ts-ignore
+            t.dateTime('createdAt')
           },
         }),
+        asNexusMethod(DateTimeResolver, 'dateTime'),
         objectType({
           name: 'User',
           isTypeOf(data) {


### PR DESCRIPTION
The dynamic output members weren't being added during the walk phase of the new interfaces implementing interfaces feature.