### PR TITLE
feat: Improved description for types on output method / output field

### DIFF
--- a/src/definitions/extendInputType.ts
+++ b/src/definitions/extendInputType.ts
@@ -9,10 +9,7 @@ export interface NexusExtendInputTypeConfig<TypeName extends string> {
 }
 
 export class NexusExtendInputTypeDef<TypeName extends string> {
-  constructor(
-    readonly name: TypeName,
-    protected config: NexusExtendInputTypeConfig<string> & { name: string }
-  ) {
+  constructor(readonly name: TypeName, protected config: NexusExtendInputTypeConfig<any> & { name: string }) {
     assertValidName(name)
   }
   get value() {

--- a/src/definitions/inputObjectType.ts
+++ b/src/definitions/inputObjectType.ts
@@ -26,7 +26,7 @@ export interface NexusInputObjectTypeConfig<TypeName extends string> {
 }
 
 export class NexusInputObjectTypeDef<TypeName extends string> {
-  constructor(readonly name: TypeName, protected config: NexusInputObjectTypeConfig<string>) {
+  constructor(readonly name: TypeName, protected config: NexusInputObjectTypeConfig<any>) {
     assertValidName(name)
   }
   get value() {

--- a/src/dynamicMethod.ts
+++ b/src/dynamicMethod.ts
@@ -43,6 +43,11 @@ export interface BaseExtensionConfig<T extends string> {
    * signature for the type
    */
   typeDefinition?: string
+  /**
+   * Description inserted above the typeDefinition for the field, will be formatted
+   * as JSDOC by Nexus
+   */
+  typeDescription?: string
 }
 
 export interface DynamicOutputMethodConfig<T extends string> extends BaseExtensionConfig<T> {

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -392,10 +392,15 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
       b.addType(
         dynamicOutputMethod({
           name: nexusFieldName,
+          typeDescription: `
+            Adds a Relay-style connection to the type, with numerous options for configuration
+
+            @see https://nexusjs.org/docs/plugins/connection
+          `,
           typeDefinition: `<FieldName extends string>(
-            fieldName: FieldName, 
-            config: connectionPluginCore.ConnectionFieldConfig<TypeName, FieldName> ${printedDynamicConfig}
-          ): void`,
+      fieldName: FieldName,
+      config: connectionPluginCore.ConnectionFieldConfig<TypeName, FieldName>${printedDynamicConfig}
+    ): void`,
           factory({ typeName: parentTypeName, typeDef: t, args: factoryArgs, stage, builder, wrapping }) {
             const [fieldName, fieldConfig] = factoryArgs as [string, ConnectionFieldConfig]
             const targetType = fieldConfig.type

--- a/tests/dynamicMethods.spec.ts
+++ b/tests/dynamicMethods.spec.ts
@@ -91,6 +91,7 @@ describe('dynamicOutputProperty', () => {
         }),
         dynamicOutputProperty({
           name: 'model',
+          typeDescription: 'Chains model fields',
           factory({ typeDef }) {
             return {
               timestamps() {

--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -11,13 +11,22 @@ import {
   queryType,
   stringArg,
   subscriptionType,
+  asNexusMethod,
+  scalarType,
 } from '../../../src'
 import { mockStream } from '../../__helpers'
 import './__typegen'
 
+export const scalar = scalarType({
+  name: 'MyCustomScalar',
+  description: 'No-Op scalar for testing purposes only',
+  asNexusMethod: 'myCustomScalar',
+})
+
 export const query = queryType({
   definition(t) {
     t.string('foo', { resolve: () => 'bar' })
+    t.myCustomScalar('customScalar')
   },
 })
 
@@ -53,6 +62,7 @@ export const i2 = objectType({
 export const dom = dynamicOutputMethod({
   name: 'title',
   typeDefinition: '(options: { escape: boolean }): void',
+  typeDescription: 'Title of the page, optionally escaped',
   factory: ({ typeDef: t }) => {
     t.string('title')
   },
@@ -67,6 +77,7 @@ export const dim = dynamicInputMethod({
 
 export const dop = dynamicOutputProperty({
   name: 'body',
+  typeDescription: 'adds a body (weirdly, as a getter)',
   factory: ({ typeDef: t }) => {
     t.string('body')
   },

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -6,16 +6,36 @@
 import { core } from '../../../src'
 declare global {
   interface NexusGenCustomInputMethods<TypeName extends string> {
+    /**
+     * No-Op scalar for testing purposes only
+     */
+    myCustomScalar<FieldName extends string>(
+      fieldName: FieldName,
+      opts?: core.ScalarInputFieldConfig<core.GetGen3<'inputTypes', TypeName, FieldName>>
+    ): void // "MyCustomScalar";
     title(...args: any): void
   }
 }
 declare global {
   interface NexusGenCustomOutputMethods<TypeName extends string> {
+    /**
+     * No-Op scalar for testing purposes only
+     */
+    myCustomScalar<FieldName extends string>(
+      fieldName: FieldName,
+      ...opts: core.ScalarOutSpread<TypeName, FieldName>
+    ): void // "MyCustomScalar";
+    /**
+     * Title of the page, optionally escaped
+     */
     title(options: { escape: boolean }): void
   }
 }
 declare global {
   interface NexusGenCustomOutputProperties<TypeName extends string> {
+    /**
+     * adds a body (weirdly, as a getter)
+     */
     body: any
   }
 }
@@ -40,6 +60,7 @@ export interface NexusGenScalars {
   Float: number
   Boolean: boolean
   ID: string
+  MyCustomScalar: any
 }
 
 export interface NexusGenObjects {
@@ -92,6 +113,7 @@ export interface NexusGenFieldTypes {
   }
   Query: {
     // field return type
+    customScalar: NexusGenScalars['MyCustomScalar'] | null // MyCustomScalar
     foo: string | null // String
     searchPosts: Array<NexusGenRootTypes['Post'] | null> | null // [Post]
     user: NexusGenRootTypes['User'] | null // User
@@ -138,6 +160,7 @@ export interface NexusGenFieldTypeNames {
   }
   Query: {
     // field return type name
+    customScalar: 'MyCustomScalar'
     foo: 'String'
     searchPosts: 'Post'
     user: 'User'

--- a/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
@@ -420,6 +420,20 @@ exports[`field level configuration can inherit the additional args from the main
 }"
 `;
 
+exports[`field level configuration prints the types associated with the connection plugin correctly 1`] = `
+"
+    /**
+     * Adds a Relay-style connection to the type, with numerous options for configuration
+     *
+     * @see https://nexusjs.org/docs/plugins/connection
+     */
+    connectionField<FieldName extends string>(
+      fieldName: FieldName,
+      config: connectionPluginCore.ConnectionFieldConfig<TypeName, FieldName>
+    ): void
+  "
+`;
+
 exports[`global plugin configuration allows disabling backward pagination 1`] = `
 "type Query {
   users(


### PR DESCRIPTION
Thought it'd be nice to be able to include documentation strings alongside dynamic methods, such as for the `connectionField`. Figured this might be useful for the stuff y'all are doing with the Prisma plugin too.