### PR TITLE
feat: Connection plugin features & fixes

### DIFF
--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -298,26 +298,26 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
   Pick<CommonFieldConfig, 'deprecation' | 'description'> &
   NexusGenPluginFieldConfig<TypeName, FieldName>
 
-const ForwardPaginateArgs = {
+export const ForwardPaginateArgs = {
   first: nullable(intArg({ description: 'Returns the first n elements from the list.' })),
   after: nullable(
     stringArg({ description: 'Returns the elements in the list that come after the specified cursor' })
   ),
 }
 
-const ForwardOnlyStrictArgs = {
+export const ForwardOnlyStrictArgs = {
   ...ForwardPaginateArgs,
   first: nonNull(intArg({ description: 'Returns the first n elements from the list.' })),
 }
 
-const BackwardPaginateArgs = {
+export const BackwardPaginateArgs = {
   last: nullable(intArg({ description: 'Returns the last n elements from the list.' })),
   before: nullable(
     stringArg({ description: 'Returns the elements in the list that come before the specified cursor' })
   ),
 }
 
-const BackwardOnlyStrictArgs = {
+export const BackwardOnlyStrictArgs = {
   ...BackwardPaginateArgs,
   last: nonNull(intArg({ description: 'Returns the last n elements from the list.' })),
 }
@@ -356,7 +356,7 @@ export type PageInfoFieldResolver<
   info: GraphQLResolveInfo
 ) => MaybePromise<ResultValue<TypeName, FieldName>['pageInfo'][EdgeField]>
 
-type EdgeLike = { cursor: string | PromiseLike<string>; node: any }
+export type EdgeLike = { cursor: string | PromiseLike<string>; node: any }
 
 export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig) => {
   const pluginConfig: ConnectionPluginConfig = { ...connectionPluginConfig }

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -91,7 +91,7 @@ export interface ConnectionPluginConfig {
     args: PaginationArgs,
     ctx: GetGen<'context'>,
     info: GraphQLResolveInfo
-  ) => { hasNextPage: boolean; hasPreviousPage: boolean }
+  ) => MaybePromise<{ hasNextPage: boolean; hasPreviousPage: boolean }>
   /**
    * Conversion from a cursor string into an opaque token. Defaults to base64Encode(string)
    */
@@ -203,7 +203,7 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
     args: ArgsValue<TypeName, FieldName>,
     ctx: GetGen<'context'>,
     info: GraphQLResolveInfo
-  ) => { hasNextPage: boolean; hasPreviousPage: boolean }
+  ) => MaybePromise<{ hasNextPage: boolean; hasPreviousPage: boolean }>
   /**
    * Whether the field allows for backward pagination
    */
@@ -786,6 +786,11 @@ export function makeResolveFn(
             hasNextPage: false,
             hasPreviousPage: false,
           }
+
+      if (isPromiseLike(basePageInfo)) {
+        basePageInfo = await basePageInfo
+      }
+
       return {
         ...basePageInfo,
         startCursor: edges?.[0]?.cursor ? edges[0].cursor : null,

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -236,7 +236,9 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
    * This will cause the resulting type to be prefix'ed with the name of the type/field it is branched off of,
    * so as not to conflict with any non-extended connections.
    */
-  extendEdge?: (def: ObjectDefinitionBlock<any>) => void
+  extendEdge?: (
+    def: ObjectDefinitionBlock<FieldTypeName<FieldTypeName<TypeName, FieldName>, 'edges'>>
+  ) => void
   /**
    * Configures the default "nonNullDefaults" for connection type generated
    * for this connection
@@ -245,7 +247,10 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
   /**
    * Allows specifying a custom cursor type, as the name of a scalar
    */
-  cursorType?: GetGen<'scalarNames'> | NexusNullDef<GetGen<'scalarNames'>>
+  cursorType?:
+    | GetGen<'scalarNames'>
+    | NexusNullDef<GetGen<'scalarNames'>>
+    | NexusNonNullDef<GetGen<'scalarNames'>>
   /**
    * Defined if you have extended the connectionPlugin globally
    */
@@ -331,7 +336,7 @@ function base64Decode(str: string) {
 }
 
 export type EdgeFieldResolver<TypeName extends string, FieldName extends string, EdgeField extends string> = (
-  root: RootValue<TypeName>,
+  root: RootValue<FieldTypeName<FieldTypeName<TypeName, FieldName>, 'edges'>>,
   args: ArgsValue<TypeName, FieldName>,
   context: GetGen<'context'>,
   info: GraphQLResolveInfo
@@ -392,7 +397,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
         eachObj(pluginExtendConnection, (val, key) => {
           dynamicConfig.push(
             `${key}${
-              val.requireResolver ? ':' : '?:'
+              val.requireResolver === false ? '?:' : ':'
             } core.FieldResolver<core.FieldTypeName<TypeName, FieldName>, "${key}">`
           )
         })
@@ -403,7 +408,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
           pluginExtendEdge,
           (val, key) =>
             `${key}${
-              val.requireResolver ? ':' : '?:'
+              val.requireResolver === false ? '?:' : ':'
             } connectionPluginCore.EdgeFieldResolver<TypeName, FieldName, "${key}">`
         )
         dynamicConfig.push(`edgeFields: { ${edgeFields.join(', ')} }`)

--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -11,8 +11,9 @@ import {
   queryType,
   stringArg,
   subscriptionType,
-  asNexusMethod,
   scalarType,
+  connectionPlugin,
+  declarativeWrappingPlugin,
 } from '../../../src'
 import { mockStream } from '../../__helpers'
 import './__typegen'
@@ -105,6 +106,20 @@ export const User = objectType({
   definition(t) {
     t.string('firstName')
     t.string('lastName')
+    t.connectionField('posts', {
+      type: Post,
+      nodes() {
+        return mockData.posts
+      },
+      edgeFields: {
+        delta(root, args, ctx) {
+          if (root.cursor) {
+            // Cursor should be defined here
+          }
+          return Object.keys(root.node ?? {}).length
+        },
+      },
+    })
   },
   rootTyping: `{ firstName: string, lastName: string }`,
 })
@@ -207,3 +222,14 @@ export const Subscription = subscriptionType({
     })
   },
 })
+
+export const plugins = [
+  declarativeWrappingPlugin({ disable: true }),
+  connectionPlugin({
+    extendEdge: {
+      delta: {
+        type: 'Int',
+      },
+    },
+  }),
+]

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -3,7 +3,7 @@
  * Do not make changes to this file directly
  */
 
-import { core } from '../../../src'
+import { core, connectionPluginCore } from '../../../src'
 declare global {
   interface NexusGenCustomInputMethods<TypeName extends string> {
     /**
@@ -29,6 +29,17 @@ declare global {
      * Title of the page, optionally escaped
      */
     title(options: { escape: boolean }): void
+    /**
+     * Adds a Relay-style connection to the type, with numerous options for configuration
+     *
+     * @see https://nexusjs.org/docs/plugins/connection
+     */
+    connectionField<FieldName extends string>(
+      fieldName: FieldName,
+      config: connectionPluginCore.ConnectionFieldConfig<TypeName, FieldName> & {
+        edgeFields: { delta: connectionPluginCore.EdgeFieldResolver<TypeName, FieldName, 'delta'> }
+      }
+    ): void
   }
 }
 declare global {
@@ -73,10 +84,27 @@ export interface NexusGenObjects {
     // root type
     hello?: string | null // String
   }
+  PageInfo: {
+    // root type
+    endCursor?: string | null // String
+    hasNextPage: boolean // Boolean!
+    hasPreviousPage: boolean // Boolean!
+    startCursor?: string | null // String
+  }
   Post: {
     // root type
     body?: string | null // String
     title?: string | null // String
+  }
+  PostConnection: {
+    // root type
+    edges?: Array<NexusGenRootTypes['PostEdge'] | null> | null // [PostEdge]
+    pageInfo: NexusGenRootTypes['PageInfo'] // PageInfo!
+  }
+  PostEdge: {
+    // root type
+    cursor: string // String!
+    node?: NexusGenRootTypes['Post'] | null // Post
   }
   Query: {}
   Subscription: {}
@@ -106,10 +134,28 @@ export interface NexusGenFieldTypes {
     // field return type
     hello: string | null // String
   }
+  PageInfo: {
+    // field return type
+    endCursor: string | null // String
+    hasNextPage: boolean // Boolean!
+    hasPreviousPage: boolean // Boolean!
+    startCursor: string | null // String
+  }
   Post: {
     // field return type
     body: string | null // String
     title: string | null // String
+  }
+  PostConnection: {
+    // field return type
+    edges: Array<NexusGenRootTypes['PostEdge'] | null> | null // [PostEdge]
+    pageInfo: NexusGenRootTypes['PageInfo'] // PageInfo!
+  }
+  PostEdge: {
+    // field return type
+    cursor: string // String!
+    delta: number | null // Int
+    node: NexusGenRootTypes['Post'] | null // Post
   }
   Query: {
     // field return type
@@ -133,6 +179,7 @@ export interface NexusGenFieldTypes {
     // field return type
     firstName: string | null // String
     lastName: string | null // String
+    posts: NexusGenRootTypes['PostConnection'] | null // PostConnection
   }
   I: {
     // field return type
@@ -153,10 +200,28 @@ export interface NexusGenFieldTypeNames {
     // field return type name
     hello: 'String'
   }
+  PageInfo: {
+    // field return type name
+    endCursor: 'String'
+    hasNextPage: 'Boolean'
+    hasPreviousPage: 'Boolean'
+    startCursor: 'String'
+  }
   Post: {
     // field return type name
     body: 'String'
     title: 'String'
+  }
+  PostConnection: {
+    // field return type name
+    edges: 'PostEdge'
+    pageInfo: 'PageInfo'
+  }
+  PostEdge: {
+    // field return type name
+    cursor: 'String'
+    delta: 'Int'
+    node: 'Post'
   }
   Query: {
     // field return type name
@@ -180,6 +245,7 @@ export interface NexusGenFieldTypeNames {
     // field return type name
     firstName: 'String'
     lastName: 'String'
+    posts: 'PostConnection'
   }
   I: {
     // field return type name
@@ -203,6 +269,15 @@ export interface NexusGenArgTypes {
     user: {
       // args
       id?: string | null // ID
+    }
+  }
+  User: {
+    posts: {
+      // args
+      after?: string | null // String
+      before?: string | null // String
+      first?: number | null // Int
+      last?: number | null // Int
     }
   }
 }

--- a/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
@@ -231,6 +231,148 @@ type PageInfo {
 }"
 `;
 
+exports[`field level configuration #515 - custom non-string cursor type 1`] = `
+"scalar UUID
+
+scalar UUID4
+
+type Query {
+  pluginLevel(
+    \\"\\"\\"Returns the first n elements from the list.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Returns the elements in the list that come after the specified cursor\\"\\"\\"
+    after: String
+
+    \\"\\"\\"Returns the last n elements from the list.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"Returns the elements in the list that come before the specified cursor\\"\\"\\"
+    before: String
+  ): UserConnection!
+  fieldLevel(
+    \\"\\"\\"Returns the first n elements from the list.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Returns the elements in the list that come after the specified cursor\\"\\"\\"
+    after: String
+
+    \\"\\"\\"Returns the last n elements from the list.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"Returns the elements in the list that come before the specified cursor\\"\\"\\"
+    before: String
+  ): QueryFieldLevel_Connection!
+  fieldLevel2(
+    \\"\\"\\"Returns the first n elements from the list.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Returns the elements in the list that come after the specified cursor\\"\\"\\"
+    after: String
+
+    \\"\\"\\"Returns the last n elements from the list.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"Returns the elements in the list that come before the specified cursor\\"\\"\\"
+    before: String
+  ): QueryFieldLevel2_Connection!
+}
+
+type UserConnection {
+  \\"\\"\\"
+  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  \\"\\"\\"
+  edges: [UserEdge!]!
+
+  \\"\\"\\"
+  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  \\"\\"\\"
+  pageInfo: PageInfo!
+}
+
+type UserEdge {
+  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  cursor: UUID!
+
+  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  node: User!
+  delta: Int!
+}
+
+\\"\\"\\"
+PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+\\"\\"\\"
+type PageInfo {
+  \\"\\"\\"
+  Used to indicate whether more edges exist following the set defined by the clients arguments.
+  \\"\\"\\"
+  hasNextPage: Boolean!
+
+  \\"\\"\\"
+  Used to indicate whether more edges exist prior to the set defined by the clients arguments.
+  \\"\\"\\"
+  hasPreviousPage: Boolean!
+
+  \\"\\"\\"
+  The cursor corresponding to the first nodes in edges. Null if the connection is empty.
+  \\"\\"\\"
+  startCursor: String
+
+  \\"\\"\\"
+  The cursor corresponding to the last nodes in edges. Null if the connection is empty.
+  \\"\\"\\"
+  endCursor: String
+}
+
+type QueryFieldLevel_Connection {
+  \\"\\"\\"
+  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  \\"\\"\\"
+  edges: [QueryFieldLevel_Edge!]!
+
+  \\"\\"\\"
+  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  \\"\\"\\"
+  pageInfo: PageInfo!
+}
+
+type QueryFieldLevel_Edge {
+  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  cursor: UUID!
+
+  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  node: User!
+  delta: Int!
+}
+
+type QueryFieldLevel2_Connection {
+  \\"\\"\\"
+  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  \\"\\"\\"
+  edges: [QueryFieldLevel2_Edge!]!
+
+  \\"\\"\\"
+  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  \\"\\"\\"
+  pageInfo: PageInfo!
+}
+
+type QueryFieldLevel2_Edge {
+  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  cursor: UUID4!
+
+  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  node: User!
+  delta: Int!
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+"
+`;
+
 exports[`field level configuration #670 should explicitly state nullability for connectionPlugin args & fields 1`] = `
 "type Query {
   users(

--- a/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
@@ -744,12 +744,12 @@ exports[`global plugin configuration can include a "nodes" field, with an array 
 
 exports[`global plugin configuration logs error if the extendConnection resolver is not specified 1`] = `
 Array [
-  [Error: Nexus Connection Plugin: Missing totalCount resolver property for Query.users],
+  [Error: Nexus Connection Plugin: Missing totalCount resolver property for Query.users. Set requireResolver to "false" on the field config if you do not need a resolver.],
 ]
 `;
 
 exports[`global plugin configuration logs error if the extendEdge resolver is not specified 1`] = `
 Array [
-  [Error: Nexus Connection Plugin: Missing edgeFields.totalCount resolver property for Query.users],
+  [Error: Nexus Connection Plugin: Missing edgeFields.totalCount resolver property for Query.users. Set requireResolver to "false" on the edge field config if you do not need a resolver.],
 ]
 `;

--- a/tests/plugins/connectionPlugin.spec.ts
+++ b/tests/plugins/connectionPlugin.spec.ts
@@ -647,6 +647,19 @@ describe('global plugin configuration', () => {
     expect(spy).toBeCalledTimes(1)
   })
 
+  it('skips error if the extendEdge resolver is not specified and requireResolver is set to false', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation()
+    makeTestSchema({
+      extendEdge: {
+        totalCount: {
+          type: 'Int',
+          requireResolver: false,
+        },
+      },
+    })
+    expect(spy).toBeCalledTimes(0)
+  })
+
   it('can configure additional fields for the edge globally', () => {
     const schema = makeTestSchema(
       {

--- a/tests/plugins/connectionPlugin.spec.ts
+++ b/tests/plugins/connectionPlugin.spec.ts
@@ -884,7 +884,7 @@ describe('field level configuration', () => {
                 return userNodes
               },
               edgeFields: {
-                delta: (root) => {
+                delta: (root: any) => {
                   return root.node.id.split(':')[1]
                 },
               },
@@ -912,7 +912,7 @@ describe('field level configuration', () => {
       document: parse(`{ users(first: 10) { edges { delta } } }`),
     })
 
-    expect(result.data?.users.edges.map((e) => e.delta)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    expect(result.data?.users.edges.map((e: any) => e.delta)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
   })
 
   it('#515 - custom non-string cursor type', async () => {

--- a/tests/plugins/connectionPlugin.spec.ts
+++ b/tests/plugins/connectionPlugin.spec.ts
@@ -963,4 +963,25 @@ describe('field level configuration', () => {
 
     expect(printSchema(schema)).toMatchSnapshot()
   })
+
+  it('#479 allows a promise to be returned from pageInfoFromNodes', async () => {
+    const schema = makeTestSchema({
+      async pageInfoFromNodes() {
+        return {
+          hasNextPage: true,
+          hasPreviousPage: false,
+        }
+      },
+    })
+
+    const result = await executeOk({
+      schema,
+      document: UsersFirst,
+      variableValues: {
+        first: 1,
+      },
+    })
+    expect(result.data?.users.pageInfo.hasNextPage).toEqual(true)
+    expect(result.data?.users.pageInfo.hasPreviousPage).toEqual(false)
+  })
 })


### PR DESCRIPTION
Fix: #450 custom edge fields are not being resolved
feat: #515 allow connection plugin cursor to be non-string type
feat: #399, add requireResolver: false to skip requiring global extension fields
feat: #479, allow promise to be returned from pageInfoFromNodes
feat: #456, export connection plugin args