### PR TITLE
chore(docs): tutorial typo nullable schema defined

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -343,7 +343,7 @@ export const PostMutation = extendType({
 ```ts
 Mutation {
 -  createDraft: Post
-+  createDraft(title: String!, body: String!): Post
++  createDraft(title: String!, body: String!): Post!
 }
 ```
 
@@ -429,7 +429,7 @@ export const PostMutation = extendType({
 
 ```ts
 type Mutation {
-  createDraft(body: String!, title: String!): Post
+  createDraft(body: String!, title: String!): Post!
 +  publish(draftId: Int!): Post
 }
 ```
@@ -496,8 +496,8 @@ export const PostQuery = extendType({
 
 ```ts
 type Query {
-  drafts: [Post!]
-+  posts: [Post!]
+  drafts: [Post]!
++  posts: [Post]
 }
 ```
 


### PR DESCRIPTION
I am getting start with tutorial.

and I found something wrong typo.

```
t.nonNull.field("createDraft", {...})
```
then, generated SDL as
```
createDraft(body: String!, title: String!): Post!
```

and

```
t.nonNull.list.field("drafts", {...}) => drafts: [Post]!
...
t.list.field("posts", { ...}}  => posts: [Post]

```
