### PR TITLE
feat: add .asArg for enum, fix default typings

### DIFF
--- a/examples/apollo-fullstack/src/fullstack-typegen.ts
+++ b/examples/apollo-fullstack/src/fullstack-typegen.ts
@@ -214,8 +214,8 @@ export type NexusGenAbstractsUsingStrategyResolveType = never
 
 export type NexusGenFeaturesConfig = {
   abstractTypeStrategies: {
-    isTypeOf: true
-    resolveType: false
+    isTypeOf: false
+    resolveType: true
     __typename: false
   }
 }
@@ -224,6 +224,7 @@ export interface NexusGenTypes {
   context: t.Context
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames
@@ -253,5 +254,7 @@ export interface NexusGenTypes {
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}
+  interface NexusGenPluginArgConfig {}
 }

--- a/examples/githunt-api/src/githunt-typegen.ts
+++ b/examples/githunt-api/src/githunt-typegen.ts
@@ -242,8 +242,8 @@ export type NexusGenAbstractsUsingStrategyResolveType = never
 
 export type NexusGenFeaturesConfig = {
   abstractTypeStrategies: {
-    isTypeOf: true
-    resolveType: false
+    isTypeOf: false
+    resolveType: true
     __typename: false
   }
 }
@@ -252,6 +252,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames
@@ -281,5 +282,7 @@ export interface NexusGenTypes {
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}
+  interface NexusGenPluginArgConfig {}
 }

--- a/examples/kitchen-sink/src/kitchen-sink.gen.ts
+++ b/examples/kitchen-sink/src/kitchen-sink.gen.ts
@@ -8,7 +8,7 @@ declare global {
   interface NexusGenCustomInputMethods<TypeName extends string> {
     date<FieldName extends string>(
       fieldName: FieldName,
-      opts?: core.ScalarInputFieldConfig<core.GetGen3<'inputTypes', TypeName, FieldName>>
+      opts?: core.CommonInputFieldConfig<TypeName, FieldName>
     ): void // "Date";
   }
 }
@@ -18,6 +18,11 @@ declare global {
       fieldName: FieldName,
       ...opts: core.ScalarOutSpread<TypeName, FieldName>
     ): void // "Date";
+    /**
+     * Adds a Relay-style connection to the type, with numerous options for configuration
+     *
+     * @see https://nexusjs.org/docs/plugins/connection
+     */
     connectionField<FieldName extends string>(
       fieldName: FieldName,
       config: connectionPluginCore.ConnectionFieldConfig<TypeName, FieldName>
@@ -522,6 +527,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames
@@ -570,6 +576,76 @@ declare global {
      * guard on a specific field if you know there's no potential for unsafe types.
      */
     skipNullGuard?: boolean
+    /**
+     * Whether the type can be null
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    nullable?: boolean
+    /**
+     * Whether the type is list of values, or just a single value. If list is true, we assume the type is a
+     * list. If list is an array, we'll assume that it's a list with the depth. The boolean indicates whether
+     * the type is required (non-null), where true = nonNull, false = nullable.
+     *
+     * @see declarativeWrappingPlugin
+     */
+    list?: true | boolean[]
+    /**
+     * Whether the type should be non null, `required: true` = `nullable: false`
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    required?: boolean
+  }
+  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {
+    /**
+     * Whether the type can be null
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    nullable?: boolean
+    /**
+     * Whether the type is list of values, or just a single value. If list is true, we assume the type is a
+     * list. If list is an array, we'll assume that it's a list with the depth. The boolean indicates whether
+     * the type is required (non-null), where true = nonNull, false = nullable.
+     *
+     * @see declarativeWrappingPlugin
+     */
+    list?: true | boolean[]
+    /**
+     * Whether the type should be non null, `required: true` = `nullable: false`
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    required?: boolean
   }
   interface NexusGenPluginSchemaConfig {}
+  interface NexusGenPluginArgConfig {
+    /**
+     * Whether the type can be null
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    nullable?: boolean
+    /**
+     * Whether the type is list of values, or just a single value. If list is true, we assume the type is a
+     * list. If list is an array, we'll assume that it's a list with the depth. The boolean indicates whether
+     * the type is required (non-null), where true = nonNull, false = nullable.
+     *
+     * @see declarativeWrappingPlugin
+     */
+    list?: true | boolean[]
+    /**
+     * Whether the type should be non null, `required: true` = `nullable: false`
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    required?: boolean
+  }
 }

--- a/examples/star-wars/src/graphql/character.ts
+++ b/examples/star-wars/src/graphql/character.ts
@@ -12,7 +12,7 @@ export const Character = interfaceType({
     t.list.field('friends', {
       type: 'Character',
       description: 'The friends of the character, or an empty list if they have none.',
-      resolve: (character) => getFriends(character),
+      resolve: (character) => Promise.all(getFriends(character)),
     })
     t.list.field('appearsIn', {
       type: 'Episode',

--- a/examples/star-wars/src/star-wars-typegen.ts
+++ b/examples/star-wars/src/star-wars-typegen.ts
@@ -173,6 +173,7 @@ export interface NexusGenTypes {
   context: swapi.ContextType
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames
@@ -208,6 +209,76 @@ declare global {
      * guard on a specific field if you know there's no potential for unsafe types.
      */
     skipNullGuard?: boolean
+    /**
+     * Whether the type can be null
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    nullable?: boolean
+    /**
+     * Whether the type is list of values, or just a single value. If list is true, we assume the type is a
+     * list. If list is an array, we'll assume that it's a list with the depth. The boolean indicates whether
+     * the type is required (non-null), where true = nonNull, false = nullable.
+     *
+     * @see declarativeWrappingPlugin
+     */
+    list?: true | boolean[]
+    /**
+     * Whether the type should be non null, `required: true` = `nullable: false`
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    required?: boolean
+  }
+  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {
+    /**
+     * Whether the type can be null
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    nullable?: boolean
+    /**
+     * Whether the type is list of values, or just a single value. If list is true, we assume the type is a
+     * list. If list is an array, we'll assume that it's a list with the depth. The boolean indicates whether
+     * the type is required (non-null), where true = nonNull, false = nullable.
+     *
+     * @see declarativeWrappingPlugin
+     */
+    list?: true | boolean[]
+    /**
+     * Whether the type should be non null, `required: true` = `nullable: false`
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    required?: boolean
   }
   interface NexusGenPluginSchemaConfig {}
+  interface NexusGenPluginArgConfig {
+    /**
+     * Whether the type can be null
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    nullable?: boolean
+    /**
+     * Whether the type is list of values, or just a single value. If list is true, we assume the type is a
+     * list. If list is an array, we'll assume that it's a list with the depth. The boolean indicates whether
+     * the type is required (non-null), where true = nonNull, false = nullable.
+     *
+     * @see declarativeWrappingPlugin
+     */
+    list?: true | boolean[]
+    /**
+     * Whether the type should be non null, `required: true` = `nullable: false`
+     *
+     * @default (depends on whether nullability is configured in type or schema)
+     * @see declarativeWrappingPlugin
+     */
+    required?: boolean
+  }
 }

--- a/examples/ts-ast-reader/src/ts-ast-reader-typegen.ts
+++ b/examples/ts-ast-reader/src/ts-ast-reader-typegen.ts
@@ -2878,6 +2878,7 @@ export interface NexusGenTypes {
   context: t.ContextType
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames
@@ -2907,5 +2908,7 @@ export interface NexusGenTypes {
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}
+  interface NexusGenPluginArgConfig {}
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -48,7 +48,7 @@ import {
   NexusOutputFieldDef,
   OutputDefinitionBlock,
 } from './definitions/definitionBlocks'
-import { EnumTypeConfig } from './definitions/enumType'
+import { NexusEnumTypeConfig } from './definitions/enumType'
 import { NexusExtendInputTypeConfig, NexusExtendInputTypeDef } from './definitions/extendInputType'
 import { NexusExtendTypeConfig, NexusExtendTypeDef } from './definitions/extendType'
 import { NexusInputObjectTypeConfig } from './definitions/inputObjectType'
@@ -555,6 +555,7 @@ export class SchemaBuilder {
     }
     if (isSchema(types)) {
       this.addTypes(types.getTypeMap())
+      return
     }
     if (isNexusPlugin(types)) {
       if (!this.plugins?.includes(types)) {
@@ -949,7 +950,7 @@ export class SchemaBuilder {
     return field
   }
 
-  private buildEnumType(config: EnumTypeConfig<any>) {
+  private buildEnumType(config: NexusEnumTypeConfig<any>) {
     const { members } = config
     const values: GraphQLEnumValueConfigMap = {}
     if (Array.isArray(members)) {

--- a/src/definitions/args.ts
+++ b/src/definitions/args.ts
@@ -10,19 +10,37 @@ export type CommonArgConfig = {
 } & NexusGenPluginArgConfig
 
 export interface ScalarArgConfig<T> extends CommonArgConfig {
-  /** Configure the default for the object */
+  /**
+   * Configure the default for the object
+   *
+   * @example
+   *   intArg({ default: 42 })
+   */
   default?: T
 }
 
-export type NexusArgConfigType<T extends AllInputTypes> = T | AllNexusInputTypeDefs<T>
+export type NexusArgConfigType<T extends string> = T | AllNexusInputTypeDefs<T>
 
-export interface NexusAsArgConfig<T extends AllInputTypes> extends CommonArgConfig {
-  /** Configure the default for the object */
-  default?: GetGen2<'allTypes', T> // TODO: Make this type-safe somehow
+export interface NexusAsArgConfig<T extends string> extends CommonArgConfig {
+  /**
+   * Sets the default value for this argument, should match the type of the argument
+   *
+   * @example
+   *   intArg({ default: 42 })
+   */
+  default?: GetGen2<'inputTypeShapes', T>
 }
 
-export interface NexusArgConfig<T extends AllInputTypes> extends NexusAsArgConfig<T> {
-  /** The type of the argument, either the string name of the type, or the concrete Nexus type definition */
+export interface NexusArgConfig<T extends string> extends NexusAsArgConfig<T> {
+  /**
+   * The type of the argument, either the string name of the type, or the concrete Nexus type definition
+   *
+   * @example
+   *   arg({ type: 'User' })
+   *
+   * @example
+   *   arg({ type: UserType })
+   */
   type: NexusArgConfigType<T>
 }
 
@@ -34,7 +52,7 @@ export interface NexusFinalArgConfig extends NexusArgConfig<any> {
 }
 
 export class NexusArgDef<TypeName extends AllInputTypes> {
-  constructor(readonly name: string, protected config: NexusArgConfig<TypeName>) {}
+  constructor(readonly name: TypeName, protected config: NexusArgConfig<any>) {}
   get value() {
     return this.config
   }
@@ -50,7 +68,7 @@ withNexusSymbol(NexusArgDef, NexusTypes.Arg)
  *
  * @see https://graphql.github.io/learn/schema/#arguments
  */
-export function arg<T extends AllInputTypes>(options: NexusArgConfig<T>) {
+export function arg<T extends string>(options: NexusArgConfig<T>) {
   if (!options.type) {
     throw new Error('You must provide a "type" for the arg()')
   }

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -189,7 +189,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
 
 export interface NexusInputFieldConfig<TypeName extends string, FieldName extends string>
   extends CommonInputFieldConfig<TypeName, FieldName> {
-  type: AllInputTypes | AllNexusInputTypeDefs<string>
+  type: AllInputTypes | AllNexusInputTypeDefs
 }
 
 export type NexusInputFieldDef = NexusInputFieldConfig<string, string> & {

--- a/src/definitions/enumType.ts
+++ b/src/definitions/enumType.ts
@@ -1,4 +1,5 @@
 import { assertValidName } from 'graphql'
+import { arg, NexusArgDef, NexusAsArgConfig } from './args'
 import { NexusTypes, RootTypingDef, withNexusSymbol } from './_types'
 
 type TypeScriptEnumLike = {
@@ -19,7 +20,7 @@ export interface EnumMemberInfo {
   deprecation?: string // | DeprecationInfo;
 }
 
-export interface EnumTypeConfig<TypeName extends string> {
+export interface NexusEnumTypeConfig<TypeName extends string> {
   name: TypeName
   /** The description to annotate the GraphQL SDL */
   description?: string | null
@@ -33,15 +34,26 @@ export interface EnumTypeConfig<TypeName extends string> {
 }
 
 export class NexusEnumTypeDef<TypeName extends string> {
-  constructor(readonly name: TypeName, protected config: EnumTypeConfig<string>) {
+  constructor(readonly name: TypeName, protected config: NexusEnumTypeConfig<string>) {
     assertValidName(name)
   }
   get value() {
     return this.config
   }
+  /**
+   * Wraps the current enum as an argument, useful if you're defining the enumType inline for an individual field.
+   *
+   * @example
+   *   args: {
+   *     sort: enumType(config).asArg({ default: 'someValue' })
+   *   }
+   */
+  asArg(cfg?: NexusAsArgConfig<TypeName>): NexusArgDef<any> {
+    return arg({ ...cfg, type: this })
+  }
 }
 withNexusSymbol(NexusEnumTypeDef, NexusTypes.Enum)
 
-export function enumType<TypeName extends string>(config: EnumTypeConfig<TypeName>) {
+export function enumType<TypeName extends string>(config: NexusEnumTypeConfig<TypeName>) {
   return new NexusEnumTypeDef(config.name, config)
 }

--- a/src/definitions/inputObjectType.ts
+++ b/src/definitions/inputObjectType.ts
@@ -24,13 +24,16 @@ export class NexusInputObjectTypeDef<TypeName extends string> {
   get value() {
     return this.config
   }
-  // FIXME
-  // Instead of `any` we want to pass the name of this type...
-  // so that the correct `cfg.default` type can be looked up
-  // from the typegen.
-  asArg(cfg?: NexusAsArgConfig<any>): NexusArgDef<any> {
-    // FIXME
-    return arg({ ...cfg, type: this } as any)
+  /**
+   * Shorthand for wrapping the current InputObject in an "arg", useful if you need to add a description.
+   *
+   * @example
+   *   inputObject(config).asArg({
+   *     description: 'Define sort the current field',
+   *   })
+   */
+  asArg(cfg?: NexusAsArgConfig<TypeName>): NexusArgDef<any> {
+    return arg({ ...cfg, type: this })
   }
 }
 withNexusSymbol(NexusInputObjectTypeDef, NexusTypes.InputObject)

--- a/src/definitions/wrapping.ts
+++ b/src/definitions/wrapping.ts
@@ -235,7 +235,9 @@ export function rewrapAsGraphQLType(baseType: GraphQLNamedType, wrapping: NexusF
     if (wrap === 'List') {
       finalType = GraphQLList(finalType)
     } else if (wrap === 'NonNull') {
-      finalType = GraphQLNonNull(finalType)
+      if (!isNonNullType(finalType)) {
+        finalType = GraphQLNonNull(finalType)
+      }
     } else {
       throw new Unreachable(wrap)
     }

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -426,17 +426,6 @@ export class TypegenPrinter {
       .join('\n')
   }
 
-  buildEnumTypeMembersMap() {
-    const enumMap: TypeMapping = {}
-    this.groupedTypes.enum.forEach((e) => {
-      enumMap[e.name] = e
-        .getValues()
-        .map((val) => JSON.stringify(val.name))
-        .join(' | ')
-    })
-    return enumMap
-  }
-
   buildEnumTypeMap() {
     const enumMap: TypeMapping = {}
     this.groupedTypes.enum.forEach((e) => {

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -131,6 +131,7 @@ export class TypegenPrinter {
         `  context: ${this.printContext()};`,
         `  inputTypes: NexusGenInputs;`,
         `  rootTypes: NexusGenRootTypes;`,
+        `  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars;`,
         `  argTypes: NexusGenArgTypes;`,
         `  fieldTypes: NexusGenFieldTypes;`,
         `  fieldTypeNames: NexusGenFieldTypeNames;`,
@@ -423,6 +424,17 @@ export class TypegenPrinter {
       .concat(`  abstractTypeStrategies: ${unionProps}`)
       .concat('}')
       .join('\n')
+  }
+
+  buildEnumTypeMembersMap() {
+    const enumMap: TypeMapping = {}
+    this.groupedTypes.enum.forEach((e) => {
+      enumMap[e.name] = e
+        .getValues()
+        .map((val) => JSON.stringify(val.name))
+        .join(' | ')
+    })
+    return enumMap
   }
 
   buildEnumTypeMap() {

--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -122,6 +122,7 @@ export type GenTypesShapeKeys =
   | 'context'
   | 'inputTypes'
   | 'rootTypes'
+  | 'inputTypeShapes'
   | 'argTypes'
   | 'fieldTypes'
   | 'fieldTypeNames'

--- a/tests/__snapshots__/backingTypes.spec.ts.snap
+++ b/tests/__snapshots__/backingTypes.spec.ts.snap
@@ -106,6 +106,7 @@ export interface NexusGenTypes {
   context: any;
   inputTypes: NexusGenInputs;
   rootTypes: NexusGenRootTypes;
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars;
   argTypes: NexusGenArgTypes;
   fieldTypes: NexusGenFieldTypes;
   fieldTypeNames: NexusGenFieldTypeNames;

--- a/tests/__snapshots__/typegenPrinter.spec.ts.snap
+++ b/tests/__snapshots__/typegenPrinter.spec.ts.snap
@@ -343,6 +343,7 @@ export interface NexusGenTypes {
   context: t.TestContext;
   inputTypes: NexusGenInputs;
   rootTypes: NexusGenRootTypes;
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars;
   argTypes: NexusGenArgTypes;
   fieldTypes: NexusGenFieldTypes;
   fieldTypeNames: NexusGenFieldTypeNames;

--- a/tests/integrations/abstractTypes/allStrategiesOptionalWhenTypeNameEnabled/__typegen.ts
+++ b/tests/integrations/abstractTypes/allStrategiesOptionalWhenTypeNameEnabled/__typegen.ts
@@ -106,6 +106,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/abstractTypes/isTypeOfsImplemented/__typegen.ts
+++ b/tests/integrations/abstractTypes/isTypeOfsImplemented/__typegen.ts
@@ -104,6 +104,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/abstractTypes/missingIsTypeOf/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingIsTypeOf/__typegen.ts
@@ -104,6 +104,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/abstractTypes/missingResolveType/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingResolveType/__typegen.ts
@@ -104,6 +104,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/abstractTypes/missingResolveTypeOrIsTypeOf/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingResolveTypeOrIsTypeOf/__typegen.ts
@@ -94,6 +94,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/abstractTypes/missingTypenameDiscriminant/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingTypenameDiscriminant/__typegen.ts
@@ -106,6 +106,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/abstractTypes/resolveTypeImplemented/__typegen.ts
+++ b/tests/integrations/abstractTypes/resolveTypeImplemented/__typegen.ts
@@ -104,6 +104,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/declarativeWrappingPlugin/__typegen.ts
+++ b/tests/integrations/declarativeWrappingPlugin/__typegen.ts
@@ -107,6 +107,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -1,9 +1,11 @@
 import {
+  arg,
   connectionPlugin,
   declarativeWrappingPlugin,
   dynamicInputMethod,
   dynamicOutputMethod,
   dynamicOutputProperty,
+  enumType,
   extendType,
   idArg,
   inputObjectType,
@@ -94,6 +96,16 @@ export const PostSearchInput = inputObjectType({
   },
 })
 
+export const someArg = arg({
+  type: inputObjectType({
+    name: 'Something',
+    definition(t) {
+      t.nonNull.int('id')
+    },
+  }),
+  default: { id: 1 },
+})
+
 export const Post = objectType({
   name: 'Post',
   definition(t) {
@@ -136,7 +148,16 @@ export const Query = extendType({
     })
     t.field('user', {
       type: 'User',
-      args: { id: idArg() },
+      args: {
+        id: idArg(),
+        status: enumType({
+          name: 'UserStatus',
+          members: [
+            { name: 'ACTIVE', value: 'active' },
+            { name: 'PENDING', value: 'pending' },
+          ],
+        }).asArg({ default: 'active' }),
+      },
       resolve: () => mockData.user,
     })
   },

--- a/tests/integrations/kitchenSink/__schema.graphql
+++ b/tests/integrations/kitchenSink/__schema.graphql
@@ -86,7 +86,11 @@ type Query {
   customScalar: MyCustomScalar
   foo: String
   searchPosts(input: PostSearchInput): [Post]
-  user(id: ID): User
+  user(id: ID, status: UserStatus = ACTIVE): User
+}
+
+input Something {
+  id: Int!
 }
 
 type Subscription {
@@ -126,4 +130,9 @@ type User {
     """
     last: Int
   ): PostConnection
+}
+
+enum UserStatus {
+  ACTIVE
+  PENDING
 }

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -50,9 +50,15 @@ export interface NexusGenInputs {
     body?: string | null // String
     title?: string | null // String
   }
+  Something: {
+    // input type
+    id: number // Int!
+  }
 }
 
-export interface NexusGenEnums {}
+export interface NexusGenEnums {
+  UserStatus: 'active' | 'pending'
+}
 
 export interface NexusGenScalars {
   String: string
@@ -108,7 +114,7 @@ export interface NexusGenUnions {}
 
 export type NexusGenRootTypes = NexusGenInterfaces & NexusGenObjects
 
-export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars
+export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars & NexusGenEnums
 
 export interface NexusGenFieldTypes {
   Mutation: {
@@ -262,6 +268,7 @@ export interface NexusGenArgTypes {
     user: {
       // args
       id?: string | null // ID
+      status: NexusGenEnums['UserStatus'] | null // UserStatus
     }
   }
   User: {
@@ -288,7 +295,7 @@ export type NexusGenObjectNames = keyof NexusGenObjects
 
 export type NexusGenInputNames = keyof NexusGenInputs
 
-export type NexusGenEnumNames = never
+export type NexusGenEnumNames = keyof NexusGenEnums
 
 export type NexusGenInterfaceNames = keyof NexusGenInterfaces
 
@@ -312,6 +319,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/integrations/unionTooComplexToRepresent/__typegen.ts
+++ b/tests/integrations/unionTooComplexToRepresent/__typegen.ts
@@ -4684,6 +4684,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames

--- a/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
@@ -135,6 +135,7 @@ export interface NexusGenTypes {
   context: any;
   inputTypes: NexusGenInputs;
   rootTypes: NexusGenRootTypes;
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars;
   argTypes: NexusGenArgTypes;
   fieldTypes: NexusGenFieldTypes;
   fieldTypeNames: NexusGenFieldTypeNames;

--- a/tests/plugins/__snapshots__/queryComplexityPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/queryComplexityPlugin.spec.ts.snap
@@ -93,6 +93,7 @@ export interface NexusGenTypes {
   context: any;
   inputTypes: NexusGenInputs;
   rootTypes: NexusGenRootTypes;
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars;
   argTypes: NexusGenArgTypes;
   fieldTypes: NexusGenFieldTypes;
   fieldTypeNames: NexusGenFieldTypeNames;

--- a/tests/typegen/types.gen.ts
+++ b/tests/typegen/types.gen.ts
@@ -196,6 +196,7 @@ export interface NexusGenTypes {
   context: any
   inputTypes: NexusGenInputs
   rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
   argTypes: NexusGenArgTypes
   fieldTypes: NexusGenFieldTypes
   fieldTypeNames: NexusGenFieldTypeNames


### PR DESCRIPTION
- Renames `EnumTypeConfig` -> `NexusEnumTypeConfig` for consistency
- Adds `.asArg` on `enumType`, since these are often defined inline for one-off field args
- Fixes types so `default` type is properly inferred, eases types elsewhere so valid types which haven't been added to the manifest do not show as type errors

Note: Saw a bunch of places where we could probably cleanup the naming of the `NexusGen`, but wanted to hold off on that until a separate PR