### PR TITLE
chore(docs): update tutorial testing chapter

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
@@ -204,6 +204,7 @@ Then, update your `Context` type so that it uses the PrismaClient created in `./
 ```ts
 // api/context.ts
 import { db } from "./db";
++import { PrismaClient } from "@prisma/client"
 
 export interface Context {
 -  db: Db
@@ -222,6 +223,7 @@ export function createContext(): Context {
 ```ts
 // api/context.ts
 import { db } from "./db";
+import { PrismaClient } from "@prisma/client"
 
 export interface Context {
   db: PrismaClient

--- a/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
@@ -196,24 +196,22 @@ export const db = new PrismaClient()
 </TabbedContent>
 
 
-Then, update your `Context` type so that it uses the PrismaClient
+Then, update your `Context` type so that it uses the PrismaClient created in `./db.ts`
 
 <TabbedContent tabs={['Diff', 'Code']}>
 <tab>
 
 ```ts
 // api/context.ts
--import { Db, db } from "./db";
-+import { PrismaClient } from '@prisma/client'
+import { db } from "./db";
 
 export interface Context {
--  db: Db;
+-  db: Db
 +  db: PrismaClient
 }
 export function createContext(): Context {
   return {
--   db,
-+   db: new PrismaClient(),
+    db,
   }
 }
 ```
@@ -223,7 +221,7 @@ export function createContext(): Context {
 
 ```ts
 // api/context.ts
-import { PrismaClient } from '@prisma/client'
+import { db } from "./db";
 
 export interface Context {
   db: PrismaClient
@@ -231,7 +229,7 @@ export interface Context {
 
 export function createContext(): Context {
   return {
-    db: new PrismaClient(),
+    db,
   }
 }
 ```

--- a/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
@@ -80,7 +80,12 @@ function graphqlTestContext() {
   return {
     async before() {
       const port = await getPort({ port: makeRange(4000, 6000) });
+
       serverInstance = await server.listen({ port });
++     // Close the Prisma Client connection when the Apollo Server is closed
++     serverInstance.server.on("close", async () => {
++       db.$disconnect() 
++     });
 
       return new GraphQLClient(`http://localhost:${port}`);
     },
@@ -149,6 +154,7 @@ import { GraphQLClient } from "graphql-request";
 import { nanoid } from "nanoid";
 import { join } from "path";
 import { Client } from "pg";
+import { db } from "../api/db";
 import { server } from "../api/server";
 
 type TestContext = {
@@ -185,7 +191,12 @@ function graphqlTestContext() {
   return {
     async before() {
       const port = await getPort({ port: makeRange(4000, 6000) });
+      
       serverInstance = await server.listen({ port });
+      // Close the Prisma Client connection when the Apollo Server is closed
+      serverInstance.server.on("close", async () => {
+        db.$disconnect() 
+      });
 
       return new GraphQLClient(`http://localhost:${port}`);
     },
@@ -299,19 +310,6 @@ it('ensures that a draft can be created and published', async () => {
 
 + expect(persistedData).toMatchInlineSnapshot()
 })
-```
-
-Before running your tests update the jest script with the `--forceExit` flag as there is currently a bug keeping just from existing normally after tests have completed.
-
-
-```json diff
-  "scripts": {
-    "dev": "ts-node-dev --transpile-only --no-notify api/app",
-    "build": "tsc",
-    "generate": "ts-node --transpile-only api/schema",
--   "test": "npm run generate && jest"
-+   "test": "npm run generate && jest --forceExit"
-  },
 ```
 
 Now run your tests


### PR DESCRIPTION
- Use the Prisma Client created in `db.ts` in the API Context
- Disconnect Prisma Client after running each test, allowing Jest to exit. Previously this was an issue as the Prisma Client connection was never closed and prevented Jest from exiting. This issue was fixed in [`a9ca189`](https://github.com/graphql-nexus/tutorial/commit/8bcbe015fa1779770caa6b9dbcce67d000ba5c9c) using a workaround by passing the `--forceExit` flag to Jest.

This PR adds a proper fix for #678 